### PR TITLE
optimal-instructions: auto-fix skill for project instruction files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ into the matching `<scope>/.<surface>/rules/` dir. It discovers every skill unde
 | [beads-extra](skills/beads-extra/) | auto | Advanced/gotcha layer for using the `bd` CLI directly — issue-type semantics, gates, bulk intake, JSON parsing |
 | [beads-authoring](skills/beads-authoring/) | auto | Conventions for building beads-backed skills — `.formula.toml`, `bd mol pour`, coordinator dispatch |
 | [skill-authoring](skills/skill-authoring/README.md) | auto | How to author, structure, and optimize Claude Code skills themselves |
+| [optimal-instructions](skills/optimal-instructions/README.md) | auto | Auto-fix skill for project instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) — token-efficiency cuts + AGENTS.md-primacy structural proposals |
 
 "auto" skills are not user-invoked directly; they trigger from their `description`
 conditions when relevant work appears.
@@ -126,6 +127,12 @@ See [skills/beads-authoring/README.md](skills/beads-authoring/README.md).
 
 ### skill-authoring
 
-How to author, structure, and optimize Claude Code skills themselves: `SKILL.md` frontmatter, progressive disclosure, the dispatch-vs-inline decision, token-efficient phrasing, file layout, and consistency/documentation discipline. Triggers automatically when creating or editing skill files.
+How to author, structure, and optimize Claude Code skills themselves: `SKILL.md` frontmatter, progressive disclosure, the dispatch-vs-inline decision, token-efficient phrasing, file layout, and consistency/documentation discipline. Triggers automatically when creating or editing skill files. Owns the token-efficiency ruleset; optimizing project-root instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) is delegated to `optimal-instructions`.
 
 See [skills/skill-authoring/README.md](skills/skill-authoring/README.md).
+
+### optimal-instructions
+
+Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root `.agents/rules/*`). On create/modify it auto-applies token-efficiency cuts (K1, citing skill-authoring's ruleset) and proposes structural relocation toward AGENTS.md-primacy / a thin CLAUDE.md `@-include` index (K2, propose-and-confirm, relocate-never-delete), then reports what changed. Triggers automatically (best-effort, description-only); not user-invocable. Handles project-root instruction files; skill-dir instruction files are skill-authoring's domain.
+
+See [skills/optimal-instructions/README.md](skills/optimal-instructions/README.md).

--- a/README.md
+++ b/README.md
@@ -133,6 +133,6 @@ See [skills/skill-authoring/README.md](skills/skill-authoring/README.md).
 
 ### optimal-instructions
 
-Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root `.agents/rules/*`). On create/modify it auto-applies token-efficiency cuts (K1, citing skill-authoring's ruleset) and proposes structural relocation toward AGENTS.md-primacy / a thin CLAUDE.md `@-include` index (K2, propose-and-confirm, relocate-never-delete), then reports what changed. Triggers automatically (best-effort, description-only); not user-invocable. Handles project-root instruction files; skill-dir instruction files are skill-authoring's domain.
+Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root `.{claude,agents}/rules/*`). On create/modify it auto-applies token-efficiency cuts (K1, citing skill-authoring's ruleset) and proposes structural relocation toward AGENTS.md-primacy / a thin CLAUDE.md `@-include` index (K2, propose-and-confirm, relocate-never-delete), then reports what changed. Triggers automatically (best-effort, description-only); not user-invocable. Handles project-root instruction files; skill-dir instruction files are skill-authoring's domain.
 
 See [skills/optimal-instructions/README.md](skills/optimal-instructions/README.md).

--- a/docs/plans/plan-002-james-dixson-b8b610/plan.md
+++ b/docs/plans/plan-002-james-dixson-b8b610/plan.md
@@ -3,12 +3,15 @@
 **ID:** plan-002-james-dixson-b8b610
 **Author:** james-dixson
 **Created:** 2026-05-31
-**Status:** approved
+**Status:** complete
 **Phase log:**
 - 2026-05-31 scoping: initial scope captured
 - 2026-05-31 drafting: scope locked from Q&A; overlap investigated; synthesizing plan
 - 2026-05-31 review: plan v1 presented; reviewer verdict REVISE; 5 concerns + 3 gaps resolved; operator chose split apply (K1 auto / K2 propose) and consistency-only verification; recorded in reviews/pass-1.md
 - 2026-05-31 approved: operator approved; audit pass
+- 2026-05-31 executing: start gate resolved
+- 2026-05-31 reconciling: all execution beads closed; no upstream to reconcile
+- 2026-05-31 complete: plan complete
 
 ## Objective
 Create `skills/optimal-instructions`, a Claude Code skill that transforms the intent of

--- a/skills/optimal-instructions/README.md
+++ b/skills/optimal-instructions/README.md
@@ -7,8 +7,8 @@ tags: []
 # optimal-instructions
 
 Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root
-`.agents/rules/*`). On create/modify it reads the file, auto-applies token-efficiency cuts, and
-proposes structural relocation toward AGENTS.md-primacy, then reports what changed.
+`.{claude,agents}/rules/*`). On create/modify it reads the file, auto-applies token-efficiency
+cuts, and proposes structural relocation toward AGENTS.md-primacy, then reports what changed.
 
 ## Prerequisites
 
@@ -31,8 +31,8 @@ project-root instruction file is created or modified. Triggering is **best-effor
 description-only skill (no rule, no hook) cannot guarantee it runs on every write. There are no
 subcommands.
 
-Scope boundary: instruction files **inside a skill directory** (a skill's `SKILL.md`,
-`agents/*.md`, its own `.agents/skills/<skill>/` files) belong to `skill-authoring`. The two
+Scope boundary: instruction files **inside a skill directory** under `.{claude,agents}/skills/<skill>/`
+(a skill's `SKILL.md`, `agents/*.md`, its own rules) belong to `skill-authoring`. The two
 skills' descriptions are mutually exclusive on this skill-dir vs project-root axis.
 
 ## Behavior model
@@ -41,7 +41,7 @@ skills' descriptions are mutually exclusive on this skill-dir vs project-root ax
 changed instruction file
         │
         ▼
-detect file kind + rules surface (AGENTS/* or .agents/rules/*)
+detect file kind + rules surface (AGENTS/*, .agents/rules/*, or .claude/rules/*)
         │
         ▼
 dispatch instruction-optimizer agent

--- a/skills/optimal-instructions/README.md
+++ b/skills/optimal-instructions/README.md
@@ -1,0 +1,74 @@
+---
+title: optimal-instructions
+created: '2026-05-31'
+tags: []
+---
+
+# optimal-instructions
+
+Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root
+`.agents/rules/*`). On create/modify it reads the file, auto-applies token-efficiency cuts, and
+proposes structural relocation toward AGENTS.md-primacy, then reports what changed.
+
+## Prerequisites
+
+- Claude Code (the skill loads as part of this repo's skill set).
+- The `skill-authoring` skill present in the same skill set — it is the single source of truth
+  for the token-efficiency (K1) ruleset this skill cites. No CLI tools beyond what Claude Code
+  provides; no `check-prereqs.sh`.
+
+## Install
+
+Installed by the repo-level `install.sh`, which auto-discovers every `skills/*/` directory. This
+skill ships **no companion rule** (`protocols/`) and **no hook**, so it needs zero install
+changes — it is picked up automatically. See the project [README](../../README.md) for
+`install.sh` flags.
+
+## Usage
+
+Not user-invocable (`user-invocable: false`). It fires from its `description` TRIGGER when a
+project-root instruction file is created or modified. Triggering is **best-effort** — a
+description-only skill (no rule, no hook) cannot guarantee it runs on every write. There are no
+subcommands.
+
+Scope boundary: instruction files **inside a skill directory** (a skill's `SKILL.md`,
+`agents/*.md`, its own `.agents/skills/<skill>/` files) belong to `skill-authoring`. The two
+skills' descriptions are mutually exclusive on this skill-dir vs project-root axis.
+
+## Behavior model
+
+```
+changed instruction file
+        │
+        ▼
+detect file kind + rules surface (AGENTS/* or .agents/rules/*)
+        │
+        ▼
+dispatch instruction-optimizer agent
+        │
+        ├─ K1 token-efficiency edits ──▶ auto-apply (write)
+        │
+        └─ K2 structural proposal ─────▶ propose ──▶ operator confirm ──▶ write (relocate, never delete)
+        │
+        ▼
+surface change report
+```
+
+- **K1** (token efficiency) cites skill-authoring `SKILL.md` "Token efficiency" §; auto-applied.
+- **K2** (AGENTS.md primary, CLAUDE.md a thin `@-include` index, behavioral rules in the rules
+  subdir) is propose-and-confirm; relocate-never-delete.
+- **Idempotent**: a no-op on already-optimized input.
+
+## Layout
+
+```
+skills/optimal-instructions/
+├── SKILL.md                          # entry point: trigger, SKILL_DIR, workflow, rules
+├── README.md                         # this file
+├── agents/
+│   └── instruction-optimizer.md      # apply agent: K1 auto + K2 proposal + change report
+└── spec/
+    ├── structure.md                  # K2 structural convention (REQ-STRUCT-*)
+    ├── apply.md                      # split-apply contract + idempotency + before/after example (REQ-APPLY-*)
+    └── integration.md                # surface detection, runtime carve-out, no-dup boundary (REQ-INT-*)
+```

--- a/skills/optimal-instructions/SKILL.md
+++ b/skills/optimal-instructions/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: optimal-instructions
 description: 'Auto-fix skill for project instruction files. On create/modify of a project
-  CLAUDE.md, AGENTS.md, AGENTS/*, or .agents/rules/* file, reads it, auto-applies
-  token-efficiency cuts, and proposes structural fixes — AGENTS.md primary, CLAUDE.md a
-  thin @-include index, behavioral rules in the project rules surface — then reports what
-  changed. TRIGGER when: a project-root instruction file (CLAUDE.md, AGENTS.md, AGENTS/*,
-  or repo-root .agents/rules/*) is created or modified. SKIP for: instruction files INSIDE
-  a skill directory (a skill''s SKILL.md, agents/*.md, or its own .agents/skills/<skill>/
-  files) — those route to skill-authoring; also application code, end-user docs, notes.
-  Distinguishing axis: this skill owns project-root instruction files; skill-authoring owns
-  skill-dir instruction files.'
+  CLAUDE.md, AGENTS.md, AGENTS/*, or repo-root .{claude,agents}/rules/* file, reads it,
+  auto-applies token-efficiency cuts, and proposes structural fixes — AGENTS.md primary,
+  CLAUDE.md a thin @-include index, behavioral rules in the project rules surface — then
+  reports what changed. TRIGGER when: a project-root instruction file (CLAUDE.md, AGENTS.md,
+  AGENTS/*, or repo-root .{claude,agents}/rules/*) is created or modified. SKIP for: instruction
+  files INSIDE a skill directory under .{claude,agents}/skills/<skill>/ (a skill''s SKILL.md,
+  agents/*.md, its own rules) — those route to skill-authoring; also application code, end-user
+  docs, notes. Distinguishing axis: this skill owns project-root instruction files (in both the
+  .claude and .agents surfaces); skill-authoring owns skill-dir instruction files.'
 user-invocable: false
 allowed-tools:
   - Read
@@ -25,7 +25,7 @@ tags: []
 # optimal-instructions
 
 Active, on-write optimizer for project instruction files (`CLAUDE.md`, `AGENTS.md`,
-`AGENTS/*`, repo-root `.agents/rules/*`). Reads the changed file, auto-applies
+`AGENTS/*`, repo-root `.{claude,agents}/rules/*`). Reads the changed file, auto-applies
 token-efficiency cuts, proposes structural relocation, and reports what changed.
 Background: see [[README]].
 
@@ -48,25 +48,39 @@ SKILL_DIR=$(find ~/.claude/skills ~/.agents/skills "$GIT_ROOT/.claude/skills" "$
 ## Scope vs skill-authoring
 
 This skill handles **project-root** instruction files. Instruction files **inside a skill
-directory** (`SKILL.md`, `agents/*.md`, a skill's own `.agents/skills/<skill>/` files) are
-skill-authoring's domain — route them there. The two skills' `description` fields are
+directory** under `.{claude,agents}/skills/<skill>/` (`SKILL.md`, `agents/*.md`, a skill's own
+rules) are skill-authoring's domain — route them there. The two skills' `description` fields are
 mutually exclusive on this skill-dir vs project-root axis.
 
 ## Surface detection
 
-The behavioral-rules subdir exists in two forms. Detect which the project uses; normalize to
-**that** surface, never impose one:
+The behavioral-rules subdir exists in three forms — `AGENTS/*` (capitalized, repo-root),
+`.agents/rules/*`, and `.claude/rules/*`. Detect which the project uses; normalize to **that**
+surface, never impose one. If the changed file is itself under a rules surface, that surface
+wins; otherwise detect an existing one:
 
 ```bash
-if [ -d "$GIT_ROOT/AGENTS" ]; then RULES_SURFACE="AGENTS"
-elif [ -d "$GIT_ROOT/.agents/rules" ]; then RULES_SURFACE=".agents/rules"
-else RULES_SURFACE="AGENTS"; fi   # default for a greenfield project
+CHANGED_FILE="<absolute path to the changed instruction file (the TARGET from step 1)>"
+case "$CHANGED_FILE" in
+  */.claude/rules/*) RULES_SURFACE=".claude/rules" ;;
+  */.agents/rules/*) RULES_SURFACE=".agents/rules" ;;
+  *)
+    for s in "AGENTS" ".agents/rules" ".claude/rules"; do
+      [ -d "$GIT_ROOT/$s" ] && RULES_SURFACE="$s" && break
+    done
+    RULES_SURFACE="${RULES_SURFACE:-AGENTS}"   # default for a greenfield project
+    ;;
+esac
 ```
+
+A project may carry both `.claude/` and `.agents/` surfaces (one often symlinked into the
+other); pick the changed file's own surface so relocations stay on the surface the operator
+is editing.
 
 ## Workflow
 
 1. Identify the changed instruction file and its kind: `CLAUDE.md` | `AGENTS.md` | `AGENTS/*`
-   | `.agents/rules/*`. If the path is inside a skill dir, stop — defer to skill-authoring.
+   | `.{claude,agents}/rules/*`. If the path is inside a skill dir, stop — defer to skill-authoring.
 2. Detect `RULES_SURFACE` (above).
 3. Dispatch the apply agent. Read `${SKILL_DIR}/agents/instruction-optimizer.md` and follow
    it. Prompt:
@@ -75,8 +89,8 @@ else RULES_SURFACE="AGENTS"; fi   # default for a greenfield project
    Read ${SKILL_DIR}/agents/instruction-optimizer.md and follow its instructions.
 
    TARGET: <absolute path to changed file>
-   FILE KIND: <CLAUDE.md | AGENTS.md | AGENTS/* | .agents/rules/*>
-   RULES SURFACE: <AGENTS | .agents/rules>
+   FILE KIND: <CLAUDE.md | AGENTS.md | AGENTS/* | .claude/rules/* | .agents/rules/*>
+   RULES SURFACE: <AGENTS | .agents/rules | .claude/rules>
    ```
 
 4. The agent returns: **K1 edited content** (auto), a **K2 proposal**, and a **change

--- a/skills/optimal-instructions/SKILL.md
+++ b/skills/optimal-instructions/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: optimal-instructions
+description: 'Auto-fix skill for project instruction files. On create/modify of a project
+  CLAUDE.md, AGENTS.md, AGENTS/*, or .agents/rules/* file, reads it, auto-applies
+  token-efficiency cuts, and proposes structural fixes — AGENTS.md primary, CLAUDE.md a
+  thin @-include index, behavioral rules in the project rules surface — then reports what
+  changed. TRIGGER when: a project-root instruction file (CLAUDE.md, AGENTS.md, AGENTS/*,
+  or repo-root .agents/rules/*) is created or modified. SKIP for: instruction files INSIDE
+  a skill directory (a skill''s SKILL.md, agents/*.md, or its own .agents/skills/<skill>/
+  files) — those route to skill-authoring; also application code, end-user docs, notes.
+  Distinguishing axis: this skill owns project-root instruction files; skill-authoring owns
+  skill-dir instruction files.'
+user-invocable: false
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Agent
+title: optimal-instructions
+created: '2026-05-31'
+tags: []
+---
+
+# optimal-instructions
+
+Active, on-write optimizer for project instruction files (`CLAUDE.md`, `AGENTS.md`,
+`AGENTS/*`, repo-root `.agents/rules/*`). Reads the changed file, auto-applies
+token-efficiency cuts, proposes structural relocation, and reports what changed.
+Background: see [[README]].
+
+## SKILL_DIR
+
+```bash
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo .)
+SKILL_DIR=$(find ~/.claude/skills ~/.agents/skills "$GIT_ROOT/.claude/skills" "$GIT_ROOT/.agents/skills" .claude/skills .agents/skills -maxdepth 1 -name optimal-instructions -type d 2>/dev/null | head -1)
+[ -z "$SKILL_DIR" ] && { echo "ERROR: optimal-instructions skill directory not found"; exit 1; }
+```
+
+## Two bodies of knowledge
+
+- **K1 — token efficiency** (cut narrative, keep templates/constraints/command blocks,
+  extract scripts). Single source of truth: **skill-authoring `SKILL.md` "Token efficiency"
+  §**. This skill cites that anchor and never restates the ruleset.
+- **K2 — instruction-file structure** (AGENTS.md primary; CLAUDE.md a thin `@-include`
+  index; behavioral rules in the project's rules surface). Owned here, in [[spec|spec/]].
+
+## Scope vs skill-authoring
+
+This skill handles **project-root** instruction files. Instruction files **inside a skill
+directory** (`SKILL.md`, `agents/*.md`, a skill's own `.agents/skills/<skill>/` files) are
+skill-authoring's domain — route them there. The two skills' `description` fields are
+mutually exclusive on this skill-dir vs project-root axis.
+
+## Surface detection
+
+The behavioral-rules subdir exists in two forms. Detect which the project uses; normalize to
+**that** surface, never impose one:
+
+```bash
+if [ -d "$GIT_ROOT/AGENTS" ]; then RULES_SURFACE="AGENTS"
+elif [ -d "$GIT_ROOT/.agents/rules" ]; then RULES_SURFACE=".agents/rules"
+else RULES_SURFACE="AGENTS"; fi   # default for a greenfield project
+```
+
+## Workflow
+
+1. Identify the changed instruction file and its kind: `CLAUDE.md` | `AGENTS.md` | `AGENTS/*`
+   | `.agents/rules/*`. If the path is inside a skill dir, stop — defer to skill-authoring.
+2. Detect `RULES_SURFACE` (above).
+3. Dispatch the apply agent. Read `${SKILL_DIR}/agents/instruction-optimizer.md` and follow
+   it. Prompt:
+
+   ```
+   Read ${SKILL_DIR}/agents/instruction-optimizer.md and follow its instructions.
+
+   TARGET: <absolute path to changed file>
+   FILE KIND: <CLAUDE.md | AGENTS.md | AGENTS/* | .agents/rules/*>
+   RULES SURFACE: <AGENTS | .agents/rules>
+   ```
+
+4. The agent returns: **K1 edited content** (auto), a **K2 proposal**, and a **change
+   report**.
+5. **Write K1 edits** (auto-apply — low-risk, reversible).
+6. **K2 is propose-and-confirm.** Present the K2 proposal to the operator. Write K2 edits
+   only after explicit confirmation. Never delete content — only relocate.
+7. Surface the change report (K1 applied, K2 proposed/applied/declined).
+
+## Idempotency
+
+Running on an already-optimized file is a no-op. The agent returns an empty K1 edit set and
+no K2 proposal when input already conforms — required because an on-write skill re-processes
+its own output on the next write.
+
+## Rules
+
+- K1 auto-applies; K2 never writes without operator confirmation.
+- Relocate, never delete (K2).
+- K1 criteria are cited from skill-authoring `SKILL.md` "Token efficiency" §, never restated
+  here or in the agent.
+- Detect and normalize to the project's existing rules surface; do not impose one.
+- This skill edits `CLAUDE.md` / `AGENTS/*` at **runtime via its apply agent** — distinct
+  from the Surface Convention §1 *installer* prohibition, which governs install-time writes.
+  See [[spec|spec/]].
+
+## Reference
+
+- [[README]] — what this skill is, when it fires, accepted limitations.
+- [[spec|spec/]] — K2 structure, split-apply contract, idempotency, surface detection, the
+  runtime carve-out, and the no-duplication boundary with skill-authoring.

--- a/skills/optimal-instructions/agents/instruction-optimizer.md
+++ b/skills/optimal-instructions/agents/instruction-optimizer.md
@@ -1,0 +1,72 @@
+---
+title: Instruction Optimizer
+created: '2026-05-31'
+tags: []
+---
+
+# Instruction Optimizer
+
+Apply agent for optimal-instructions. Reads one project instruction file, computes
+token-efficiency edits (K1) and a structural-relocation proposal (K2), and returns both plus a
+change report. Distinct from skill-authoring's read-only `optimizer.md`: this agent produces an
+edit set the caller applies.
+
+## Inputs
+
+- `TARGET` — absolute path to the changed instruction file.
+- `FILE KIND` — `CLAUDE.md` | `AGENTS.md` | `AGENTS/*` | `.agents/rules/*`.
+- `RULES SURFACE` — `AGENTS` | `.agents/rules` (the project's detected behavioral-rules subdir).
+
+## K1 — token efficiency (auto-apply)
+
+Apply the Cut / Keep / Extract ruleset from **skill-authoring `SKILL.md` "Token efficiency" §**.
+That section is the single source of truth — do **not** restate it here. Read it, apply it to
+`TARGET`, and produce the edited content.
+
+Per spec `apply.md` REQ-APPLY-006, never cut or break literal command blocks, behavioral
+constraints, or output-format specs (skill-authoring's "Keep" list).
+
+## K2 — structure (propose only, never write)
+
+Compute a structural-relocation proposal per spec `structure.md`:
+
+- AGENTS.md is primary (REQ-STRUCT-001).
+- CLAUDE.md is a thin `@-include` index + Claude-only essentials (REQ-STRUCT-002).
+- Behavioral rules relocate to `${RULES_SURFACE}/<concern>.md`, one concern per file
+  (REQ-STRUCT-003).
+
+Use `RULES SURFACE` as given — do not switch a project's surface (REQ-INT-003). Relocate, never
+delete (REQ-APPLY-003). Emit the proposal as a concrete set of moves; do not write any file.
+
+## Idempotency
+
+If `TARGET` already conforms, return an empty K1 edit set and no K2 proposal (REQ-APPLY-004).
+
+## Output
+
+```markdown
+## Instruction Optimization: <TARGET>
+
+### File kind / rules surface
+<FILE KIND> / <RULES SURFACE>
+
+### K1 — token-efficiency edits (auto-apply)
+<full edited file content, or "No K1 edits — already optimized.">
+
+### K2 — structural proposal (confirm before writing)
+<enumerated moves, each as: FROM <file:section> TO <file> — <one-line reason>.
+ Or "No K2 proposal — structure already conforms.">
+
+### Change report
+- K1: <what was cut, by category — narrative / soft guidance / decorative / redundant ref>
+- K2: <relocations proposed, count + targets>
+- Preserved: <command blocks / constraints / templates left intact>
+```
+
+## Rules
+
+- K1 auto-applies; **never write K2** — the agent only proposes; the caller writes on confirmation.
+- Relocate, never delete (K2).
+- Cite skill-authoring `SKILL.md` "Token efficiency" § for K1 criteria; never restate the ruleset.
+- Use the passed `RULES SURFACE`; never impose a different surface.
+- Idempotent: a no-op on already-optimized input.

--- a/skills/optimal-instructions/agents/instruction-optimizer.md
+++ b/skills/optimal-instructions/agents/instruction-optimizer.md
@@ -14,8 +14,8 @@ edit set the caller applies.
 ## Inputs
 
 - `TARGET` — absolute path to the changed instruction file.
-- `FILE KIND` — `CLAUDE.md` | `AGENTS.md` | `AGENTS/*` | `.agents/rules/*`.
-- `RULES SURFACE` — `AGENTS` | `.agents/rules` (the project's detected behavioral-rules subdir).
+- `FILE KIND` — `CLAUDE.md` | `AGENTS.md` | `AGENTS/*` | `.claude/rules/*` | `.agents/rules/*`.
+- `RULES SURFACE` — `AGENTS` | `.agents/rules` | `.claude/rules` (the project's detected behavioral-rules subdir).
 
 ## K1 — token efficiency (auto-apply)
 

--- a/skills/optimal-instructions/spec/apply.md
+++ b/skills/optimal-instructions/spec/apply.md
@@ -1,0 +1,94 @@
+# Apply Specification (split-apply contract + idempotency)
+
+The contract for how edits are applied: K1 auto, K2 propose-and-confirm.
+
+REQ-APPLY-001: K1 (token-efficiency cuts) is auto-applied. The main session writes K1 edits
+without operator confirmation.
+Rationale: K1 cuts are low-risk, reversible, and reported; gating them on confirmation adds
+friction without safety.
+Verification: SKILL.md Workflow step 5; `agents/instruction-optimizer.md` output (K1 edited content).
+
+REQ-APPLY-002: K2 (structural relocation) is propose-and-confirm. The agent emits a *proposal*;
+the main session writes K2 edits only after explicit operator confirmation.
+Rationale: Demoting CLAUDE.md and relocating operator-authored governance is destructive and
+could break projects relying on current placement.
+Verification: SKILL.md Workflow step 6; `agents/instruction-optimizer.md` Rules (never write K2).
+
+REQ-APPLY-003: Relocate, never delete. K2 moves content between files; it never removes content
+outright. Every relocation appears in the operator-visible change report.
+Rationale: Content the agent misreads as narrative may encode a behavioral constraint; relocation
+is recoverable, deletion is not.
+Verification: `agents/instruction-optimizer.md` Rules; change-report format (relocations enumerated).
+
+REQ-APPLY-004: Idempotency. Running the skill on an already-optimized file is a no-op — empty K1
+edit set, no K2 proposal.
+Rationale: An on-write skill re-processes its own output on the next write; non-idempotent
+behavior would oscillate or accrete edits.
+Verification: `agents/instruction-optimizer.md` idempotency rule; the before/after example below
+(running again on the "after" state yields no findings).
+
+REQ-APPLY-005: K1 criteria are cited, never restated. The agent names **skill-authoring `SKILL.md`
+"Token efficiency" §** as the criteria source and does not reproduce the Cut/Keep/Extract ruleset.
+Rationale: Restating K1 would violate the one-source-of-truth principle the skill enforces.
+Verification: `agents/instruction-optimizer.md` K1 section cites the anchor; grep shows no Cut/Keep
+ruleset copied into this skill.
+
+REQ-APPLY-006: Preserve literal command blocks, behavioral constraints, and output-format specs.
+These are never cut by K1 nor relocated in a way that breaks them.
+Rationale: They are output contracts and behavior gates, not narrative.
+Verification: `agents/instruction-optimizer.md` "What to keep" defers to skill-authoring's Keep list.
+
+## Acceptance example (before / after)
+
+Falsifiable behavior, no separate fixture harness needed.
+
+**Before** — a project `CLAUDE.md`:
+
+```markdown
+# MyProject
+
+This file provides guidance to Claude when working in this repository. Please be thorough
+and consider all the implications of your changes carefully.
+
+## Build
+
+To build the project, run the build command. You might want to run it like this:
+
+    make build
+
+## Testing Rules
+
+Always run tests before committing. Never push if tests fail. Use `make test`.
+```
+
+**After K1 (auto-applied)** — narrative intro and soft guidance cut, command block kept:
+
+```markdown
+# MyProject
+
+## Build
+
+    make build
+
+## Testing Rules
+
+Always run tests before committing. Never push if tests fail. Use `make test`.
+```
+
+**After K2 (proposed, written on confirmation)** — CLAUDE.md demoted to an index; the
+behavioral "Testing Rules" relocated to the detected rules surface; build context moved to
+AGENTS.md:
+
+`CLAUDE.md`:
+```markdown
+# MyProject
+
+@AGENTS.md
+@AGENTS/TESTING.md
+```
+
+`AGENTS.md` (gains the build section), `AGENTS/TESTING.md` (gains the testing rules, verbatim —
+relocated, not rewritten).
+
+Running the skill again on this "after" state produces no K1 edits and no K2 proposal
+(REQ-APPLY-004).

--- a/skills/optimal-instructions/spec/integration.md
+++ b/skills/optimal-instructions/spec/integration.md
@@ -1,0 +1,41 @@
+# Integration Specification (surface detection, carve-out, boundary)
+
+How this skill coexists with skill-authoring and adapts to a project's rules surface.
+
+REQ-INT-001: No duplication with skill-authoring. K1 (token efficiency) lives only in
+skill-authoring; K2 (structure) lives only in this skill's `spec/`. Each skill references the
+other rather than restating.
+Rationale: The skill enforces one-source-of-truth; duplicating either body across the two skills
+is the anti-pattern it exists to prevent.
+Verification: grep shows no Cut/Keep/Extract ruleset in optimal-instructions; grep shows no
+AGENTS.md-primacy / CLAUDE.md-index ruleset in skill-authoring (skill-authoring references this
+skill for it).
+
+REQ-INT-002: The two skills' `description` fields are mutually exclusive on the skill-dir vs
+project-root axis. optimal-instructions TRIGGERs on project-root instruction files and SKIPs
+skill-dir ones; skill-authoring SKIPs project-root instruction files and routes them here.
+Rationale: Both skills can match `CLAUDE.md`/`AGENTS.md`; the distinguishing axis must live in
+both descriptions so routing is unambiguous.
+Verification: both SKILL.md frontmatter `description` fields name the axis; Epic 4.1 cross-check.
+
+REQ-INT-003: Surface detection. The skill recognizes both behavioral-rule subdir forms —
+`AGENTS/*` (capitalized, repo-root) and `.agents/rules/*` — and normalizes K2 relocations to the
+surface the project already uses. It does not impose one on a project that has the other.
+Rationale: Forcing a surface switch would fight the project's existing convention.
+Verification: SKILL.md "Surface detection" block; `agents/instruction-optimizer.md` uses the
+passed `RULES SURFACE`.
+
+REQ-INT-004: Runtime carve-out vs Surface Convention §1. skill-authoring's Surface Convention §1
+forbids a skill's *installer* from writing to `AGENTS/` or editing `CLAUDE.md`. This skill edits
+those files at **runtime via its apply agent** — a different mechanism, explicitly permitted.
+Rationale: A consistency reviewer would otherwise read the runtime edits as a Surface Convention
+violation. They are not: §1 governs install-time writes only.
+Verification: SKILL.md Rules (runtime carve-out note); this REQ.
+
+REQ-INT-005: No companion rule, no hook. The skill ships no `protocols/` rule and registers no
+hook; install.sh auto-discovers it with zero changes. Triggering is via `description` only —
+best-effort, not guaranteed on every write.
+Rationale: Locked scope chose description-only triggering; install.sh installs companion rules
+only when a `protocols/` dir exists.
+Verification: `ls skills/optimal-instructions/` shows no `protocols/`; install.sh §auto-discovery
+needs no edit; README documents the limitation.

--- a/skills/optimal-instructions/spec/integration.md
+++ b/skills/optimal-instructions/spec/integration.md
@@ -18,10 +18,13 @@ Rationale: Both skills can match `CLAUDE.md`/`AGENTS.md`; the distinguishing axi
 both descriptions so routing is unambiguous.
 Verification: both SKILL.md frontmatter `description` fields name the axis; Epic 4.1 cross-check.
 
-REQ-INT-003: Surface detection. The skill recognizes both behavioral-rule subdir forms —
-`AGENTS/*` (capitalized, repo-root) and `.agents/rules/*` — and normalizes K2 relocations to the
-surface the project already uses. It does not impose one on a project that has the other.
-Rationale: Forcing a surface switch would fight the project's existing convention.
+REQ-INT-003: Surface detection. The skill recognizes all three behavioral-rule subdir forms —
+`AGENTS/*` (capitalized, repo-root), `.agents/rules/*`, and `.claude/rules/*` — and normalizes K2
+relocations to the surface the project already uses. Both the `.claude` and `.agents` surfaces are
+in scope. When the changed file is itself under a rules surface, that surface wins; otherwise an
+existing surface is detected. It does not impose one on a project that has another.
+Rationale: Forcing a surface switch would fight the project's existing convention; a project may
+carry both `.claude` and `.agents` surfaces (one often symlinked into the other).
 Verification: SKILL.md "Surface detection" block; `agents/instruction-optimizer.md` uses the
 passed `RULES SURFACE`.
 

--- a/skills/optimal-instructions/spec/structure.md
+++ b/skills/optimal-instructions/spec/structure.md
@@ -10,14 +10,14 @@ the portable file keeps instructions reachable by other harnesses.
 Verification: `agents/instruction-optimizer.md` K2 proposal logic; the before/after example in `apply.md`.
 
 REQ-STRUCT-002: `CLAUDE.md` is a thin index. It carries `@-include` directives pointing at
-`AGENTS.md` and `AGENTS/*` (or `.agents/rules/*`), plus only Claude-specific essentials that
-have no portable home (e.g. an Upstream-Tracking block).
+`AGENTS.md` and the rules subdir (`AGENTS/*`, `.agents/rules/*`, or `.claude/rules/*`), plus
+only Claude-specific essentials that have no portable home (e.g. an Upstream-Tracking block).
 Rationale: Every line of CLAUDE.md is always-loaded Claude context; content that belongs in
 the portable surface should not be duplicated into it.
 Verification: K2 proposal demotes non-`@-include`, non-essential CLAUDE.md content to a relocation proposal.
 
-REQ-STRUCT-003: Behavioral rules live in the project's rules-subdir surface — `AGENTS/*` or
-`.agents/rules/*` — one concern per file.
+REQ-STRUCT-003: Behavioral rules live in the project's rules-subdir surface — `AGENTS/*`,
+`.agents/rules/*`, or `.claude/rules/*` — one concern per file.
 Rationale: Factoring shared behavioral rules into their own file (vs inlining in AGENTS.md or
 CLAUDE.md) is the deduplication the convention exists to enforce.
 Verification: K2 proposal relocates behavioral-rule blocks to `${RULES_SURFACE}/<concern>.md`.

--- a/skills/optimal-instructions/spec/structure.md
+++ b/skills/optimal-instructions/spec/structure.md
@@ -1,0 +1,29 @@
+# Structure Specification (K2)
+
+The instruction-file structural convention this skill owns. K2 is defined **here only** —
+skill-authoring does not restate it (see `integration.md` REQ-INT-001).
+
+REQ-STRUCT-001: `AGENTS.md` is the primary project instruction file. Project context,
+command reference, and orientation live there.
+Rationale: AGENTS.md is the cross-harness surface; CLAUDE.md is Claude-specific. Primacy in
+the portable file keeps instructions reachable by other harnesses.
+Verification: `agents/instruction-optimizer.md` K2 proposal logic; the before/after example in `apply.md`.
+
+REQ-STRUCT-002: `CLAUDE.md` is a thin index. It carries `@-include` directives pointing at
+`AGENTS.md` and `AGENTS/*` (or `.agents/rules/*`), plus only Claude-specific essentials that
+have no portable home (e.g. an Upstream-Tracking block).
+Rationale: Every line of CLAUDE.md is always-loaded Claude context; content that belongs in
+the portable surface should not be duplicated into it.
+Verification: K2 proposal demotes non-`@-include`, non-essential CLAUDE.md content to a relocation proposal.
+
+REQ-STRUCT-003: Behavioral rules live in the project's rules-subdir surface — `AGENTS/*` or
+`.agents/rules/*` — one concern per file.
+Rationale: Factoring shared behavioral rules into their own file (vs inlining in AGENTS.md or
+CLAUDE.md) is the deduplication the convention exists to enforce.
+Verification: K2 proposal relocates behavioral-rule blocks to `${RULES_SURFACE}/<concern>.md`.
+
+REQ-STRUCT-004: K2 content placement is the only structural authority. What belongs in
+AGENTS.md vs CLAUDE.md vs the rules subdir is decided by REQ-STRUCT-001..003; the apply agent
+applies these and nothing beyond them.
+Rationale: A single authoritative placement rule prevents drift between agent behavior and spec.
+Verification: `agents/instruction-optimizer.md` cites these REQs for placement decisions.

--- a/skills/skill-authoring/README.md
+++ b/skills/skill-authoring/README.md
@@ -12,9 +12,12 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 
 - **Structure.** Where skill files live, when to extract a script or module, what the directory layout looks like.
 - **Skill Surface Convention.** How skills install companion rules, store config and state, register hooks, and run preflight. Seven elements, adopt as a contract. Full spec in [[SURFACE_CONVENTION|reference/SURFACE_CONVENTION.md]].
-- **Token efficiency.** What to cut and what to keep so always-loaded context stays tight.
+- **Token efficiency.** What to cut and what to keep so always-loaded context stays tight. This
+  is the single source of truth for the token-efficiency ruleset; `optimal-instructions` cites it.
 - **Python helpers.** `uv run` discipline, PEP 723 inline deps, argument parsers, runtime-cache rules.
-- **Review pipeline.** Three read-only review agents (general, optimizer, red-team) plus a Python-specific reviewer.
+- **Review pipeline.** Three read-only review agents (general, optimizer, red-team) plus a
+  Python-specific reviewer. The optimizer covers **skill-dir** instruction files; project-root
+  instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) are the `optimal-instructions` skill's domain.
 
 ## What this skill does NOT cover
 
@@ -23,6 +26,7 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 - Planning a skill's design beyond conventions — that belongs in the project's planning skill.
 - Backend-specific protocol surfaces (beads vocabulary, protocol verbs, etc.) — those live in their own skills.
 - Protocol-specific meta-conventions that overlay these rules — those live in protocol-specific authoring skills, applied *after* these conventions.
+- Optimizing **project-root** instruction files (CLAUDE.md, AGENTS.md, AGENTS/* not under a skill dir) — that is the `optimal-instructions` skill's domain. The token-efficiency ruleset is shared from here; only the trigger surface differs.
 
 ## When to read what
 
@@ -31,7 +35,7 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 - Writing an agent file inside a multi-agent skill → [[PIPELINE|reference/PIPELINE.md]].
 - Referencing skill-internal files from a script → [[PORTABILITY|reference/PORTABILITY.md]].
 - Reviewing an existing skill → see § Review sequence in [[SKILL]].
-- Trimming an instruction file → dispatch the [[optimizer|agents/optimizer.md]] agent.
+- Trimming a skill-dir instruction file → dispatch the [[optimizer|agents/optimizer.md]] agent. For a project-root instruction file, use the `optimal-instructions` skill.
 
 ## Layout shipped by this skill
 
@@ -41,7 +45,7 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 ├── README.md                       # this file
 ├── agents/
 │   ├── reviewer.md                 # general skill review
-│   ├── optimizer.md                # token-efficiency optimizer (any instruction file)
+│   ├── optimizer.md                # token-efficiency optimizer (skill-dir instruction files)
 │   ├── red-team.md                 # adversarial skill check
 │   └── python-reviewer.md          # Python helper review
 ├── reference/

--- a/skills/skill-authoring/README.md
+++ b/skills/skill-authoring/README.md
@@ -21,7 +21,7 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 
 ## What this skill does NOT cover
 
-- Application code outside `.agents/skills/`.
+- Application code outside `.{claude,agents}/skills/`.
 - End-user documentation or operator-facing notes.
 - Planning a skill's design beyond conventions — that belongs in the project's planning skill.
 - Backend-specific protocol surfaces (beads vocabulary, protocol verbs, etc.) — those live in their own skills.
@@ -40,7 +40,7 @@ Conventions for Claude Code skills, agents, and instruction files. Read by human
 ## Layout shipped by this skill
 
 ```
-.agents/skills/skill-authoring/
+.{claude,agents}/skills/skill-authoring/
 ├── SKILL.md
 ├── README.md                       # this file
 ├── agents/

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -4,15 +4,18 @@ description: 'Conventions for authoring Claude Code skills, agents, and instruct
   files. Covers directory layout, the inline-vs-script threshold, modularization,
   token-efficient writing rules, AND Python helper scripts for skills (uv invocation
   discipline, PEP 723 inline deps, argument parsers). TRIGGER when: creating or editing
-  a skill under `.agents/skills/`, scaffolding agents, authoring `SKILL.md` / `CLAUDE.md`
-  / agent prompt content, writing/editing a `.py` script under `.agents/skills/` to
+  a skill under `.agents/skills/`, `.claude/skills/`, scaffolding agents, authoring a skill''s
+  `SKILL.md` / agent prompt content, writing/editing a `.py` script under `.agents/skills/` or `.claude/skills/` to
   run via `uv run`, adding PEP 723 inline metadata, or asking how to structure skill
-  helpers and instruction files. SKIP for: writing application code outside skills,
-  end-user docs, or notes; planning a skill''s design beyond conventions (use the
-  project planning skill); backend-specific protocol surfaces (verbs, invocation,
-  translation tables — use the relevant protocol skill); meta-reviewers that overlay
-  these conventions for a specific protocol (use the protocol-specific authoring skill
-  after applying these conventions).'
+  helpers and instruction files. SKIP for: project-root instruction files (CLAUDE.md,
+  AGENTS.md, AGENTS/* NOT inside a skill dir) — those route to optimal-instructions;
+  writing application code outside skills, end-user docs, or notes; planning a skill''s
+  design beyond conventions (use the project planning skill); backend-specific protocol
+  surfaces (verbs, invocation, translation tables — use the relevant protocol skill);
+  meta-reviewers that overlay these conventions for a specific protocol (use the
+  protocol-specific authoring skill after applying these conventions). Distinguishing
+  axis: skill-authoring owns skill-dir instruction files; optimal-instructions owns
+  project-root ones.'
 user-invocable: false
 title: skill-authoring
 created: '2026-05-24'
@@ -62,6 +65,10 @@ uv run ${SKILL_DIR}/scripts/manifest_update.py ${SKILL_DIR}/protocols
 ## Token efficiency
 
 Always-loaded context (SKILL.md, CLAUDE.md, AGENTS.md, `.agents/rules/*`) must stay tight.
+This Cut/Keep/Extract ruleset is the single source of truth for token efficiency; the
+`optimal-instructions` skill cites it rather than restating it. The *structural* convention
+for project-root instruction files (AGENTS.md primary, CLAUDE.md a thin `@-include` index,
+behavioral rules in the rules subdir) is owned by `optimal-instructions`, not here.
 
 ### Cut
 
@@ -172,7 +179,7 @@ Watch for:
 Three read-only agents. All dispatched via the Agent tool. Caller applies fixes.
 
 1. [[reviewer|agents/reviewer.md]] — general skill review (structure, token efficiency, trigger quality, scope, design, portability).
-2. [[optimizer|agents/optimizer.md]] — token-efficiency optimizer for any instruction file (SKILL.md, agent .md, `.agents/rules/*.md`, AGENTS.md). Returns ranked findings + suggested edits.
+2. [[optimizer|agents/optimizer.md]] — token-efficiency optimizer for skill-dir instruction files (SKILL.md, agent .md, a skill's own `.agents/rules/*.md`). Returns ranked findings + suggested edits. Project-root instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) are `optimal-instructions`' domain.
 3. [[red-team|agents/red-team.md]] — adversarial check: what does this skill miss, where does it overcommit, what assumptions break.
 
 For Python helpers, also run [[python-reviewer|agents/python-reviewer.md]] (toolchain + design critique).

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -4,8 +4,9 @@ description: 'Conventions for authoring Claude Code skills, agents, and instruct
   files. Covers directory layout, the inline-vs-script threshold, modularization,
   token-efficient writing rules, AND Python helper scripts for skills (uv invocation
   discipline, PEP 723 inline deps, argument parsers). TRIGGER when: creating or editing
-  a skill under `.agents/skills/`, `.claude/skills/`, scaffolding agents, authoring a skill''s
-  `SKILL.md` / agent prompt content, writing/editing a `.py` script under `.agents/skills/` or `.claude/skills/` to
+  a skill under `.{claude,agents}/skills/*` (user `~/` or project `<git-root>/`), scaffolding
+  agents, authoring a skill''s `SKILL.md` / agent prompt content, writing/editing a `.py` script
+  under `.{claude,agents}/skills/*` to
   run via `uv run`, adding PEP 723 inline metadata, or asking how to structure skill
   helpers and instruction files. SKIP for: project-root instruction files (CLAUDE.md,
   AGENTS.md, AGENTS/* NOT inside a skill dir) — those route to optimal-instructions;
@@ -28,7 +29,7 @@ Rules for Claude Code skills and instruction files. Background and worked exampl
 
 ## Layout
 
-- Skill root: `.agents/skills/<skill>/`.
+- Skill root: `.{claude,agents}/skills/<skill>/`.
 - Entry point: `SKILL.md`.
 - Helpers and modules adjacent to `SKILL.md`.
 - Optional: `README.md` (one paragraph), `agents/`, `protocols/`, `hooks/`, `reference/`, `scripts/`.
@@ -36,7 +37,7 @@ Rules for Claude Code skills and instruction files. Background and worked exampl
 ## Script threshold
 
 - Inline glue and one-off snippets stay inline.
-- Scripts >~25 lines or reused → file under `.agents/skills/<skill>/`.
+- Scripts >~25 lines or reused → file under `.{claude,agents}/skills/<skill>/`.
 - Logic >~200 lines → factor into modules adjacent to `SKILL.md`.
 - CLI entrypoints use a real argument parser, never ad-hoc `sys.argv` slicing.
 
@@ -47,7 +48,7 @@ Adopt the whole contract or none of it. Full spec + worked example: [[SURFACE_CO
 1. **Companion rules.** Source: `${SKILL_DIR}/protocols/<NAME>.md`. Installed by the repo installer (`install.sh`), not `<skill> init`, to a rules dir anchored by install scope and surface — `--scope user` → `~/.<surface>/rules/<NAME>.md`, `--scope project` → `<git-root>/.<surface>/rules/<NAME>.md` (`--surface claude|agents`). Never write to `AGENTS/`. Never edit `CLAUDE.md`.
 2. **Hash manifest.** `protocols/manifest.json` (`schema_version`, `files[<NAME>] = {sha256, version, deprecated, previous_versions[]}`). Preflight checks installed-rule hash against manifest. Six outcomes: match / older-version / drift / deprecated / missing-from-disk / orphan. Unknown `schema_version` → preflight FAIL.
 3. **Config files.** `.<skill>.json` (committed) and `.<skill>.local.json` (gitignored), both at repo root, both optional. Config = operator decisions. State ≠ config.
-4. **Local state.** `.state/<skill>/`. Skill scripts write runtime cache here only. Never under the skill source dir. Never under `.claude/`.
+4. **Local state.** `.state/<skill>/`. Skill scripts write runtime cache here only. Never under the skill source dir. Never under `.{claude,agents}/`.
 5. **Hook installation.** Skills that register Claude Code hooks declare them in `hooks/manifest.json` and merge into `.claude/settings.json` via `<skill> init`. Idempotent. `<skill> uninstall` removes them.
 6. **Gitignore stewardship.** The `.gitignore` carries enumerated anchored entries `/.<skill>.local.json` and `/.state/` (no globs). **Preflight ensures these** (§7), not just init.
 7. **Preflight contract.** `<skill> preflight` both **checks** (deps, installed-rule hash, config readability, hooks) and **ensures** the idempotent scaffold (required dirs + §6 gitignore anchors — additive-only, reported, gated by a `scaffold-ensured` state version so it runs once and won't fight an operator who removes an anchor). Returns structured JSON; non-OK checks block verb execution (rule problems → re-run `install.sh`; deps/consent problems → `<skill> init`). init shrinks to consent-only setup.
@@ -64,7 +65,7 @@ uv run ${SKILL_DIR}/scripts/manifest_update.py ${SKILL_DIR}/protocols
 
 ## Token efficiency
 
-Always-loaded context (SKILL.md, CLAUDE.md, AGENTS.md, `.agents/rules/*`) must stay tight.
+Always-loaded context (SKILL.md, CLAUDE.md, AGENTS.md, `.{claude,agents}/rules/*`) must stay tight.
 This Cut/Keep/Extract ruleset is the single source of truth for token efficiency; the
 `optimal-instructions` skill cites it rather than restating it. The *structural* convention
 for project-root instruction files (AGENTS.md primary, CLAUDE.md a thin `@-include` index,
@@ -138,7 +139,7 @@ Run as `uv run script.py <args>` or — with the shebang + `chmod +x` — as `./
 
 ### Runtime cache files
 
-Helpers that persist runtime state write to `.state/<skill>/` at the repo root. Never under the skill source dir, never under `.claude/`. The skill source tree is read-only at runtime. Same rule as Skill Surface Convention §4; restated here because Python helpers are where the violation usually happens.
+Helpers that persist runtime state write to `.state/<skill>/` at the repo root. Never under the skill source dir, never under `.{claude,agents}/`. The skill source tree is read-only at runtime. Same rule as Skill Surface Convention §4; restated here because Python helpers are where the violation usually happens.
 
 Resolve the target from caller-supplied `project_root`; do not hardcode `cwd`:
 
@@ -179,7 +180,7 @@ Watch for:
 Three read-only agents. All dispatched via the Agent tool. Caller applies fixes.
 
 1. [[reviewer|agents/reviewer.md]] — general skill review (structure, token efficiency, trigger quality, scope, design, portability).
-2. [[optimizer|agents/optimizer.md]] — token-efficiency optimizer for skill-dir instruction files (SKILL.md, agent .md, a skill's own `.agents/rules/*.md`). Returns ranked findings + suggested edits. Project-root instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) are `optimal-instructions`' domain.
+2. [[optimizer|agents/optimizer.md]] — token-efficiency optimizer for skill-dir instruction files (SKILL.md, agent .md, a skill's own `.{claude,agents}/rules/*.md`). Returns ranked findings + suggested edits. Project-root instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) are `optimal-instructions`' domain.
 3. [[red-team|agents/red-team.md]] — adversarial check: what does this skill miss, where does it overcommit, what assumptions break.
 
 For Python helpers, also run [[python-reviewer|agents/python-reviewer.md]] (toolchain + design critique).

--- a/skills/skill-authoring/agents/optimizer.md
+++ b/skills/skill-authoring/agents/optimizer.md
@@ -6,7 +6,7 @@ tags: []
 
 # Optimizer
 
-Token-efficiency optimizer for **skill-dir** always-loaded instruction files: `SKILL.md`, agent `.md`, a skill's own `.agents/rules/*.md`. Read-only. Returns ranked findings + concrete suggested edits.
+Token-efficiency optimizer for **skill-dir** always-loaded instruction files: `SKILL.md`, agent `.md`, a skill's own `.{claude,agents}/rules/*.md`. Read-only. Returns ranked findings + concrete suggested edits.
 
 Scope: project-root instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*` not under a skill dir) are the `optimal-instructions` skill's domain — defer them there. The token-efficiency ruleset itself is shared (skill-authoring `SKILL.md` "Token efficiency" §); only the trigger surface differs.
 

--- a/skills/skill-authoring/agents/optimizer.md
+++ b/skills/skill-authoring/agents/optimizer.md
@@ -6,7 +6,9 @@ tags: []
 
 # Optimizer
 
-Token-efficiency optimizer for any always-loaded instruction file: `SKILL.md`, agent `.md`, `.agents/rules/*.md`, `AGENTS.md`, `CLAUDE.md`. Read-only. Returns ranked findings + concrete suggested edits.
+Token-efficiency optimizer for **skill-dir** always-loaded instruction files: `SKILL.md`, agent `.md`, a skill's own `.agents/rules/*.md`. Read-only. Returns ranked findings + concrete suggested edits.
+
+Scope: project-root instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*` not under a skill dir) are the `optimal-instructions` skill's domain — defer them there. The token-efficiency ruleset itself is shared (skill-authoring `SKILL.md` "Token efficiency" §); only the trigger surface differs.
 
 Complement to [[reviewer|agents/reviewer.md]]: reviewer evaluates conformance to skill-authoring conventions. Optimizer evaluates each line for whether it earns its token cost.
 

--- a/skills/skill-authoring/reference/SURFACE_CONVENTION.md
+++ b/skills/skill-authoring/reference/SURFACE_CONVENTION.md
@@ -86,7 +86,7 @@ If you can't decide which bucket a value belongs in, ask: *would a fresh clone o
 
 Per-skill state and cache at `.state/<skill>/`. The whole `.state/` dir is gitignored once at repo root (§6).
 
-Skill scripts that write runtime cache files **must** write under `.state/<skill>/`. Never under the skill's source directory, never under `.claude/`. The skill's source dir is read-only at runtime; any file the skill writes is per-checkout state and belongs in `.state/`.
+Skill scripts that write runtime cache files **must** write under `.state/<skill>/`. Never under the skill's source directory, never under `.{claude,agents}/`. The skill's source dir is read-only at runtime; any file the skill writes is per-checkout state and belongs in `.state/`.
 
 This rule extends to the Python helper convention in [[SKILL]] § Python helpers — runtime caches written by helper scripts go under `.state/<skill>/`, not adjacent to the script.
 


### PR DESCRIPTION
## Summary

Adds `skills/optimal-instructions`, a new auto-fix skill for **project-root** instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root `.{claude,agents}/rules/*`), and integrates it with `skill-authoring` without duplication. Executes plan-002-james-dixson-b8b610.

### optimal-instructions (new skill)
On create/modify of a project instruction file it:
- **K1 — token efficiency:** auto-applies cuts, *citing* skill-authoring's "Token efficiency" § (single source of truth — never restated).
- **K2 — structure:** proposes AGENTS.md-primacy / thin CLAUDE.md `@-include` index / behavioral rules in the rules subdir. Propose-and-confirm, relocate-never-delete.
- Idempotent (no-op on already-optimized input).
- Surface detection recognizes all three rules forms — `AGENTS/*`, `.agents/rules/*`, `.claude/rules/*` — and normalizes to the surface the project already uses (changed file's own surface wins).

Files: `SKILL.md`, `agents/instruction-optimizer.md`, `spec/{structure,apply,integration}.md`, `README.md`.

### skill-authoring (integration + surface normalization)
- `description` SKIP clause + body defer **project-root** instruction files to optimal-instructions; optimizer scope narrowed to **skill-dir** files. The two skills' descriptions are mutually exclusive on the skill-dir vs project-root axis.
- Token-efficiency § marked the single source of truth for K1.
- One-sided surface references normalized to the `.{claude,agents}/` shorthand; triggering now covers skill files under either surface in user (`~/`) or project (`<git-root>/`) context. Genuinely Claude-specific refs (find resolvers, `.claude/settings.json` hooks, `~/.claude/CLAUDE.md`, `.claude/rules` dev fallback) left as-is.

### Docs
Project README + skill READMEs updated. `install.sh` auto-discovers the skill (no companion rule, no hook) — zero install changes.

## Verification
- CONSISTENCY.md sub-agents run on both changed skills: **PASS, no FAIL** (all 4 categories + spec compliance + frontmatter audit). Cross-checks confirm the K1 anchor resolves and the descriptions are mutually exclusive.
- `spec/` approved by the operator — now the active, enforced source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)