### PR TITLE
plan-003: beads-upstream skill, M2 memory adoption, plugin-bridge corrections

### DIFF
--- a/AGENTS/MEMORY.md
+++ b/AGENTS/MEMORY.md
@@ -1,3 +1,0 @@
-# Project Memory
-
-No active memories. Entries superseded by AGENTS/ rules are pruned automatically.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ into the matching `<scope>/.<surface>/rules/` dir. It discovers every skill unde
 | [beads-authoring](skills/beads-authoring/) | auto | Conventions for building beads-backed skills — `.formula.toml`, `bd mol pour`, coordinator dispatch |
 | [skill-authoring](skills/skill-authoring/README.md) | auto | How to author, structure, and optimize Claude Code skills themselves |
 | [optimal-instructions](skills/optimal-instructions/README.md) | auto | Auto-fix skill for project instruction files (CLAUDE.md, AGENTS.md, AGENTS/*) — token-efficiency cuts + AGENTS.md-primacy structural proposals |
+| [beads-upstream](skills/beads-upstream/README.md) | `/beads-upstream` | Configurable, GitHub-first upstream tracking — push open/deferred beads to an issue tracker as a land-the-plane step; upstream issues as the worklist |
 
 "auto" skills are not user-invoked directly; they trigger from their `description`
 conditions when relevant work appears.
@@ -136,3 +137,9 @@ See [skills/skill-authoring/README.md](skills/skill-authoring/README.md).
 Auto-fix skill for project instruction files (`CLAUDE.md`, `AGENTS.md`, `AGENTS/*`, repo-root `.{claude,agents}/rules/*`). On create/modify it auto-applies token-efficiency cuts (K1, citing skill-authoring's ruleset) and proposes structural relocation toward AGENTS.md-primacy / a thin CLAUDE.md `@-include` index (K2, propose-and-confirm, relocate-never-delete), then reports what changed. Triggers automatically (best-effort, description-only) and ships an always-loaded companion rule (`protocols/INSTRUCTIONS.md`) as the on-write token-efficiency backstop; not user-invocable. Handles project-root instruction files; skill-dir instruction files are skill-authoring's domain.
 
 See [skills/optimal-instructions/README.md](skills/optimal-instructions/README.md).
+
+### beads-upstream
+
+Configurable, GitHub-first upstream-tracking utility skill (no formula/coordinator). Binds a beads workspace to an issue tracker via `/beads-upstream init` (backend `github` | `gitlab` | `jira` | `none`, where `none` fully disables tracking as a re-enableable, first-class choice). Its **push step** is a land-the-plane action — push open/deferred beads upstream, dry-run-first and scoped (`bd github push <ids>`), never a bare `bd <backend> sync`; re-push is idempotent via the recorded `External:` mapping (verified live on bd 1.0.5). Its **status/pull** step treats upstream issues as the authoritative worklist when enabled, or falls back to local `bd ready`/`bd list` when disabled. GitHub is implemented and tested; GitLab/Jira are config-only stubs. Ships an always-loaded companion rule (`protocols/UPSTREAM_TRACKING.md`) carrying the close-time push trigger (silent no-op when disabled) and the never-bare-sync invariant. Prereqs: `bd` >= 1.0.5, `uv`, `git`, and `gh` (for the GitHub backend).
+
+See [skills/beads-upstream/README.md](skills/beads-upstream/README.md).

--- a/docs/plans/plan-003-james-dixson-adacc7/README.md
+++ b/docs/plans/plan-003-james-dixson-adacc7/README.md
@@ -1,0 +1,35 @@
+# plan-003-james-dixson-adacc7
+
+> Adopt bd remember (M2 clone-local memory) and build a beads-upstream skill (GitHub-first), with plugin-bridge refactors to beads-extra/beads-authoring
+
+This plan folder is **portable**. A reader should be able to understand the
+plan's purpose, environment, reviewer history, and upstream context from the
+files here alone — without access to the drafting conversation.
+
+## File map
+
+- `plan.md` — the plan. Authoritative status, phase log, objective, motivation,
+  approach, epics, gates, risks, success criteria.
+- `context.md` — project environment snapshot (tool versions, paths, operator,
+  runtime assumptions) at the time the plan was authored.
+- `references/` — inlined upstream issue bodies (`upstream-<N>.md`), one file
+  per non-excluded row in plan.md's Upstream Issues table. Snapshots, not live.
+- `reviews/` — reviewer verdicts (`pass-<N>.md`), one file per review cycle,
+  in strict correspondence with the phase log's review lines.
+- `findings/` — investigation experiment results (if any).
+- `scope-answers.md` — scoping questionnaire answers (if complex scoping ran).
+- `upstream-triage.md` — upstream disposition working file (source of truth is
+  plan.md's Upstream Issues table; this file stays for context).
+- `assets/` — diagrams, attachments, generated artifacts.
+
+## Reading order
+
+1. `plan.md` Objective + Motivation → why this plan exists
+2. `context.md` → what environment it assumes
+3. `references/` → upstream issues it addresses
+4. `plan.md` Approach + Epics → how it will be executed
+5. `reviews/` → what reviewers flagged and how it was resolved
+6. `plan.md` Phase log → full history
+
+**Read only from this folder.** If documentation outside this folder is
+required to understand the plan, the portability contract has been violated.

--- a/docs/plans/plan-003-james-dixson-adacc7/context.md
+++ b/docs/plans/plan-003-james-dixson-adacc7/context.md
@@ -1,0 +1,71 @@
+# Project Environment Context
+
+_Snapshot taken at plan-authoring time. Cold readers: verify these values
+against the current environment before acting. The snapshot header below
+records the machine and date of capture._
+
+## Project environment
+
+`beads-skills` is a repository of beads-backed Claude Code skills (published as
+`dixson3/beads-backed-skills`). It ships skills under `skills/<name>/` — each a
+`SKILL.md` plus optional `agents/`, `scripts/`, `formulas/`, `protocols/`
+(companion rules + `manifest.json`), `spec/`, and `README.md`. Skills are
+installed into a `.claude` or `.agents` tree by the repo-root `install.sh`, which
+auto-discovers every `skills/*/` dir with a `SKILL.md` and surfaces each skill's
+`protocols/*.md` to the rules dir via `install_rules`. Authoring is governed by
+`AGENTS/CONSISTENCY.md`, `AGENTS/OPTIMIZED_SKILLS.md`, `AGENTS/DOCUMENTATION.md`,
+and the `skill-authoring` skill. Task tracking is `bd` (beads, 1.0.5); the
+project's own upstream issue tracker is GitHub (`gh issue` against
+`dixson3/beads-backed-skills`). This plan adds a `beads-upstream` skill, adopts
+`bd remember` (M2 clone-local memory), and corrects `beads-extra`/`beads-authoring`
+against the newly installed `beads` plugin.
+
+## Tool inventory
+
+<!-- snapshot: host=d3-mbp-m5.local date=2026-06-01 -->
+
+- `bd`: bd version 1.0.5 (Homebrew)
+- `git`: git version 2.50.1 (Apple Git-155)
+- `uv`: uv 0.11.17 (a33a629d6 2026-05-28 aarch64-apple-darwin)
+- `python`: Python 3.14.2
+- `gh`: gh version 2.93.0 (2026-05-27)
+- `glab`: glab 1.100.0 (e345ca67)
+- `claude`: 2.1.159 (Claude Code)
+
+## Paths
+
+- Repo root (capture machine): the `beads-skills` working tree at plan-authoring time.
+- Working directory at plan creation: repo root.
+- Plan directory: `docs/plans/plan-003-james-dixson-adacc7` (relative to repo root).
+
+## Operator identity
+
+- Git user: `james-dixson` (James Dixson, dixson3@gmail.com, Yoshiko Studios LLC; GitHub `dixson3`).
+- Authority scope: repo owner. Conservative git policy — commit/push only on explicit
+  authorization. New module/LICENSE attribution defaults to MIT, current year, James Dixson / Yoshiko Studios LLC.
+
+## Runtime assumptions
+
+- macOS (darwin), `zsh`. `direnv` is active in the repo and may alter the shell on `cd`.
+- `bd` 1.0.5 initialized in `.beads/` (per-project dolt mode; a DoltHub remote `origin` exists).
+- Network access to GitHub; `gh` authenticated for `dixson3/beads-backed-skills`.
+- `uv` available for `uv run` PEP-723 scripts (bdplan/bdresearch managers).
+- Side-effect permissions: live upstream pushes (`bd github sync`) are **irreversible** and must
+  be `--dry-run`-gated and operator-confirmed; build-time push testing uses a throwaway GitHub
+  repo, never this one. The `beads-upstream` work is documentation/skill authoring plus isolated-DB
+  probes — no writes to this repo's beads data beyond normal bdplan intake.
+
+## Adjacent-concept glossary
+
+- **Companion rule** — a `protocols/*.md` file a skill ships that `install.sh` surfaces to the
+  always-loaded rules dir; carries the minimal trigger contract (cf. `PLANS.md`, `RESEARCH.md`).
+- **M2 (clone-local memory)** — `bd remember` stored in the per-project dolt DB, injected at
+  `bd prime`, never synced upstream; durable knowledge instead goes to `AGENTS/` rules or beads.
+- **External mapping** — the upstream issue URL `bd` records on a bead after a push, used to keep
+  re-pushes idempotent (`bd show <id>` → `External:`).
+
+## Additional context
+
+The installed `beads` plugin (1.0.5, `~/.claude/plugins/.../beads/1.0.5/`) ships `resources/`
+docs that are pre-1.0.5 in places (stale gate/chemistry verbs); Epic 3 realigns
+`beads-extra`/`beads-authoring` as the 1.0.5-correct corrective layer rather than duplicating them.

--- a/docs/plans/plan-003-james-dixson-adacc7/plan.md
+++ b/docs/plans/plan-003-james-dixson-adacc7/plan.md
@@ -1,0 +1,122 @@
+# Plan: Adopt bd remember (M2 clone-local memory) and build a beads-upstream skill (GitHub-first), with plugin-bridge refactors to beads-extra/beads-authoring
+
+**ID:** plan-003-james-dixson-adacc7
+**Author:** james-dixson
+**Created:** 2026-06-01
+**Status:** complete
+**Phase log:**
+- 2026-06-01 scoping: initial scope captured
+- 2026-06-01 scoping: operator decisions locked (M2 per-project memory; GitHub-first; D3 folded in)
+- 2026-06-01 drafting: plan v1 presented
+- 2026-06-01 review: plan v1 presented
+- 2026-06-01 drafting: review pass-1 concerns resolved (revised in place); awaiting operator approval
+- 2026-06-01 drafting: 2.2/2.7 revised: ship minimal companion rule (protocols/UPSTREAM_TRACKING.md + manifest), lean on description-triggering for intent entry points
+- 2026-06-01 approved: operator approved; portability audit pass
+- 2026-06-01 approved: amended: backend 'none' (fully-disabled) is a first-class config option
+- 2026-06-01 executing: start gate resolved
+- 2026-06-01 complete: plan complete: 3 epics closed, beads-upstream shipped, plugin-bridge corrected, memory M2 adopted
+
+## Objective
+
+Three coupled deliverables, all triggered by installing the user-scope `beads` plugin (bd 1.0.5):
+
+1. **Memory (M2):** adopt `bd remember` as clone-local working memory and deprecate `AGENTS/MEMORY.md`.
+2. **`beads-upstream` skill:** generalize pybridge's `UPSTREAM_TRACKING.md` into a configurable, GitHub-first skill that pushes open/deferred beads to an issue tracker as a land-the-plane step.
+3. **Plugin-bridge refactors:** correct/realign `beads-extra` and `beads-authoring` against the now-installed (and partly stale) `beads` plugin resource docs.
+
+## Motivation
+
+Installing the `beads` plugin (1.0.5) created three frictions in this repo:
+
+- The plugin's `bd prime` SessionStart hook instructs every agent to use `bd remember` and **not** `MEMORY.md` files, directly contradicting this repo's `CLAUDE.md` (`@AGENTS/MEMORY.md` include + "review AGENTS/MEMORY.md on session start"). Agents now receive conflicting memory instructions every session.
+- bd 1.0.5 ships first-class `bd github`/`bd gitlab`/`bd jira` upstream sync. The pybridge repo already encodes a working "dolt local-only + push open/deferred beads to GitHub" discipline (`~/workspace/evri/pybridge/AGENTS/UPSTREAM_TRACKING.md`), but it is hand-written per-project and GitHub-only. Generalizing it into a skill makes the discipline reusable and backend-configurable.
+- The plugin's `resources/` docs are pre-1.0.5 (0.60.0/ACF-era) and wrong in places (`bd gate approve`/`eval`/`close`, bare `bd pour`/`bd wisp`, `bd mol catalog`). `beads-extra`/`beads-authoring` are the 1.0.5-verified layer and must explicitly correct, not silently overlap, the plugin.
+
+## Upstream Issues
+
+No open issue on `dixson3/beads-backed-skills` (#2–#8) relates to this work; all are pre-existing bdplan enhancements. No upstream incorporation, no reconcile gate. New follow-ups discovered during execution are filed via `gh issue` per repo convention.
+
+## Investigation Findings
+
+No separate investigation phase — the bd 1.0.5 CLI surface was verified directly against the installed binary during scoping:
+
+- **Upstream backends:** `bd github`, `bd gitlab`, `bd jira` exist (plus `linear.*` config). `bd <backend> sync` supports `--push-only`, `--pull-only`, `--issues <csv>`, `--parent <id>` (mutually exclusive with `--issues`), `--dry-run`, and conflict policy (`--prefer-newer|local|github`). `bd <backend> status` exists. Config namespaces: `github.owner/repo/token` (+ env `GITHUB_TOKEN`), `jira.*`, `gitlab.*`.
+- **Memory:** `bd remember`/`bd recall`/`bd memories`/`bd forget`; stored in the project dolt DB, injected at `bd prime`. JSONL export does **not** carry memories and "is not cross-machine sync." Cross-machine memory requires a dolt remote on the holding DB.
+- **`--global`/`beads_global`:** a single shared DB (`beads_global`), not per-project DBs in a shared server. Machine-global at most; still not cross-machine without a dolt remote. Operator chose strict per-project (M2), so `--global` is not used.
+- **Stale plugin docs confirmed against binary:** gate verbs are `create|check|resolve` (no `approve`/`eval`/`close`); chemistry is `bd mol pour`/`bd mol wisp` (bare `bd pour`/`bd wisp` → `unknown command`).
+- **`-t` enum (authoritative `bd create --help`):** `bug|feature|task|epic|chore|decision` (custom types need `types.custom` config). `event` is created via `--type=event` (gated by `--event-*` flags), `gate` via `bd gate create`/formula — **not** general `-t` issue types. `beads-extra/SKILL.md:29` currently reads `bug | feature | task | epic | chore | molecule | gate | event`: it **omits `decision`**, lists **`molecule`** (a chemistry artifact, not a `-t` type), and treats `gate|event` as plain `-t` types without noting their special creation paths. Epic 3.2 corrects this.
+
+**Build-time verification (not plan blockers), to perform during Epic 2/3:**
+- Run `bd github sync --push-only --issues <id> --dry-run` and capture exact output shape + the `External:` mapping format it records, in a throwaway repo — **never** a bare sync against this repo.
+- In an isolated DB (`bd --db /tmp/probe.db …`), probe `bd create -t {decision,gate,event,molecule}` to settle exactly which are accepted before rewriting the `beads-extra` list (Epic 3.2).
+
+## Approach
+
+- **Epic 1 (memory)** is independent and small: documentation-only edits in `CLAUDE.md` + removal of `AGENTS/MEMORY.md`, plus a grep sweep for dangling references. Triggers `optimal-instructions` (project instruction-file change).
+- **Epic 2 (beads-upstream)** is the substantial deliverable: a **utility skill** (not a formula/coordinator beads-orchestration skill — no `bd mol pour`). It owns an `init` flow, a land-the-plane push step, and a status/pull step, with GitHub fully implemented and GitLab/Jira as config-only stubs sharing the same verb shape. The push trigger is a **skill-invoked step** (cross-harness portable), explicitly **not** a `settings.json` hook. Reliability comes from a **minimal always-loaded companion rule** (shipped under `protocols/`, like `bdplan`/`bdresearch`) that binds the close-time push trigger + the never-bare-sync invariant; all procedure lives in the SKILL.md, which leans on description-triggering for intent-based entry points (`init`, `status`). Auto-discovered by `install.sh` (no edit); added to the project README.
+- **Epic 3 (plugin-bridge)** is corrective documentation work on `beads-extra`/`beads-authoring`: a "corrects-the-plugin" callout, a `-t` type-list fix, and converting duplicated dependency-taxonomy into citations to the plugin's stable docs.
+
+Each epic ends with the repo's mandated checks: `AGENTS/CONSISTENCY.md` (sub-agent per modified skill), `AGENTS/DOCUMENTATION.md` (README sync), `AGENTS/OPTIMIZED_SKILLS.md` (token-efficiency), and `skill-authoring`/`optimal-instructions` where their triggers fire.
+
+## Epics
+
+### Epic 1: Memory adoption (M2) — deprecate AGENTS/MEMORY.md
+- Issue 1.1: Rewrite the **Memory** section of `CLAUDE.md` with the M2 split — ephemeral/clone-local working memory → `bd remember`/`bd memories`/`bd recall` (injected at `bd prime`, never synced upstream); durable/cross-clone/behavioral knowledge → `AGENTS/` rules or a filed-and-upstreamed bead. **State the rationale**: `bd remember` is project-DB-local and not carried in JSONL export, so per the operator's global portability rule it must NOT be promoted to durable/portable use — durable knowledge stays in `AGENTS/` rules or upstreamed beads. Remove the `@AGENTS/MEMORY.md` include and the "review AGENTS/MEMORY.md on session start / prune superseded entries" instruction.
+- Issue 1.2: Delete `AGENTS/MEMORY.md`.
+  - depends-on: 1.1
+- Issue 1.3: Grep sweep — confirm no remaining references to `AGENTS/MEMORY.md` anywhere (README, other `AGENTS/` rules, skills, install.sh). Fix any found. Run `optimal-instructions` on the changed `CLAUDE.md`.
+  - depends-on: 1.2
+
+### Epic 2: beads-upstream skill (GitHub-first)
+- Issue 2.1: Scaffold `skills/beads-upstream/` — `SKILL.md` (YAML frontmatter, `user-invocable: true`, `allowed-tools`), `README.md` per `DOCUMENTATION.md`. Establish it as a **utility skill** (no formula/coordinator). **Trigger split (the load-bearing design):** the SKILL.md `description` carries the *intent*-triggered entry points only — `init`, `status`/pull, "set up upstream tracking", "push beads upstream" — which description-matching catches reliably. The *procedural* trigger (push at session-close / land-the-plane) is NOT reliably caught by a description, so it lives in the always-loaded companion rule (2.7), not the description. Gate: entry leaf.
+  - depends-on: start-gate
+- Issue 2.2: Implement `/beads-upstream init` — detect git remote → propose backend (`github|gitlab|jira|none`) → confirm via `AskUserQuestion`; write `<backend>.*` config via `bd config set`; document the inline-token auth pattern (`TOKEN=$(...) bd <backend> sync …`, never persisted). **`none` is a first-class choice — upstream tracking fully disabled.** Selecting `none` writes an explicit disabled marker (e.g. `custom.upstream.enabled=false`, `custom.upstream.backend=none` via `bd config set`) so the state is *opted-out*, not *unconfigured*; init completes cleanly and re-running `init` can re-enable. **`dolt.local-only` guard:** detect current value; if a dolt remote is already configured, confirm with the operator before flipping `local-only=true` (they may run a remote intentionally). `init` configures the backend only — it does **not** write any rule file into the target project (the trigger contract ships as the skill's companion rule, 2.7).
+  - depends-on: 2.1
+- Issue 2.3: Implement the land-the-plane **push step** — **first read the upstream config; if `custom.upstream.enabled=false` / backend `none`, no-op cleanly** (report "upstream tracking disabled" and exit 0 — no enumeration, no prompt). Otherwise: enumerate open/deferred beads (helper script, defensive JSON per `beads-extra`); `--dry-run` scoped push (`--push-only --issues <ids>` or `--parent`); operator confirm; push; record `External:` mappings. Hard guard against bare `bd <backend> sync`. **Failure paths (required):** (a) pre-flight auth check — verify the token resolves before any push; fail fast with a clear message if empty/expired. (b) Partial-push handling — on non-zero `bd sync` exit, re-enumerate `External:` mappings, report pushed-vs-remaining beads, and surface (never swallow) the error. (c) **Idempotency checkpoint (gates this issue's completion):** verify via dry-run + a real scoped push in the throwaway test repo that a re-push of an already-mapped bead does **not** duplicate upstream. If `--push-only --issues` does not record the mapping the way bare `sync` does, redesign the recovery story before declaring 2.3 done — the skill's safety rests on this.
+  - depends-on: 2.2
+- Issue 2.4: Implement the **status/pull** step — when disabled (`none`), report "upstream tracking disabled" and fall back to local `bd ready`/`bd list` as the worklist. When enabled, enumerate upstream issues as the authoritative worklist (not just local beads), ordered by labels/priority.
+  - depends-on: 2.2
+- Issue 2.5: Generalize across backends — GitHub implemented and dry-run-tested; GitLab/Jira as config-only stubs with a verb/translation table and an explicit "unverified; Jira field model differs" note. The stubs may claim the **same** `--push-only --issues/--parent --dry-run` flag shape — cite the Investigation Finding that verified these flags on backend-generic `bd <backend> sync` rather than asserting it.
+  - depends-on: 2.3, 2.4
+- Issue 2.6: Extract any JSON-parsing/orchestration bash into a `scripts/` Python helper (`uv run`, PEP 723) per `OPTIMIZED_SKILLS.md`.
+  - depends-on: 2.3
+- Issue 2.7: **Author the companion rule** `skills/beads-upstream/protocols/UPSTREAM_TRACKING.md` + `manifest.json` (vendor `manifest_update.py`, run it to stamp the hash), mirroring `bdplan`/`bdresearch`. `install.sh` needs **no edit** — it auto-discovers `skills/*/` and `install_rules` surfaces `protocols/*.md` to the rules dir (verified). **Prune the rule to the minimal trigger contract** (model on PLANS.md, ~15-20 lines): (a) the close-time trigger — on push-like ops / session or plan close / "land the plane", invoke `/beads-upstream` to push **open + deferred** beads upstream, **unless upstream tracking is disabled (`none`), in which case the trigger is a silent no-op** (so opted-out projects are never nagged); (b) the one safety invariant — never bare `bd <backend> sync`; always `--push-only` + scoped `--issues`/`--parent` + `--dry-run` first; (c) a one-line pointer to the SKILL for config/backends/auth. Everything else (init flow, backend table, failure handling) stays in SKILL.md, loaded only on activation. Add to project `README.md` skills index + prerequisites table + per-skill summary (`DOCUMENTATION.md`). Reference the push step from the land-the-plane / bdplan handoff narrative.
+  - depends-on: 2.5, 2.6
+- Issue 2.8: Run `AGENTS/CONSISTENCY.md` consistency sub-agent on `skills/beads-upstream/`; fix FAIL items; draft `spec/` if none exists.
+  - depends-on: 2.7
+
+### Epic 3: Plugin-bridge refactors (beads-extra / beads-authoring)
+- Issue 3.1: R1 — add a "corrects-the-plugin" callout to `beads-extra` naming the stale plugin resources (`ASYNC_GATES.md` `bd gate approve`/`eval`/`close`; `CHEMISTRY_PATTERNS.md` bare `bd pour`/`bd wisp`/`bd mol catalog`) and stating this skill wins for 1.0.5.
+  - depends-on: start-gate
+- Issue 3.2: R3 — fix the `beads-extra/SKILL.md:29` `bd create -t` list. Current text: `bug | feature | task | epic | chore | molecule | gate | event`. Probe an isolated DB (`bd --db /tmp/probe.db create -t {decision,gate,event,molecule}`) and correct against `bd create --help` (authoritative enum: `bug|feature|task|epic|chore|decision`): **add `decision`**, **remove `molecule`** (chemistry artifact, not a `-t` type), and either drop `gate`/`event` from the `-t` list or annotate their special creation paths (`gate` via `bd gate create`/formula; `event` via `--type=event` + `--event-*` flags). Update the surrounding prose (the "`gate` is first-class" note) to match.
+  - depends-on: start-gate
+- Issue 3.3: R2/R4 — convert duplicated dependency-type taxonomy in `beads-extra`/`beads-authoring` into citations to the plugin's stable `resources/DEPENDENCIES.md` and `resources/WORKFLOWS.md`, keeping only the mutation/gotcha mechanics the plugin lacks.
+  - depends-on: 3.1, 3.2
+- Issue 3.4: Run `AGENTS/CONSISTENCY.md` sub-agent on `skills/beads-extra/` and `skills/beads-authoring/`; sync both READMEs (`DOCUMENTATION.md`); fix FAIL items.
+  - depends-on: 3.3
+
+## Gates
+
+### Start Gate (mandatory)
+- Type: human
+- Approvers: operator
+
+No capability gates (no external preconditions; GitHub push is validated by `--dry-run` at build, not a human gate). No reconcile gate (no upstream issues incorporated).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `beads-upstream` live push has irreversible side effects (creates real upstream issues) | Skill bakes in `--dry-run`-first + scoped `--issues`/`--parent` + operator confirm; **never** bare-sync. Build-time idempotency/live-push testing uses a **throwaway GitHub repo under the operator's account** (real repo needed so `External:` mapping formats), created for the test and torn down after — never this repo. |
+| Re-push after partial failure duplicates upstream issues | Idempotency checkpoint in 2.3 verifies `External:`-mapping suppresses re-push before the step is declared done; auth pre-flight + partial-failure reporting prevent blind re-runs. |
+| Removing `AGENTS/MEMORY.md` leaves dangling `@`-includes or instructions | Issue 1.3 grep sweep across repo before close. |
+| `beads-extra` `-t` assertion wrong again | Issue 3.2 re-probes the live binary before asserting. |
+| Jira/GitLab stubs imply tested support | Stubs explicitly labelled unverified; Jira field-model divergence called out. |
+| Push step / bdplan land-the-plane integration drifts from `bd` reality | Reference, don't restate, `bd <backend> sync` flags; cite `beads-extra` for JSON parsing. |
+
+## Success Criteria
+
+1. `CLAUDE.md` contains no `@AGENTS/MEMORY.md` include; `AGENTS/MEMORY.md` is deleted; the Memory section states the M2 split; `grep -ri 'AGENTS/MEMORY.md'` over the repo is clean (excluding this plan + git history).
+2. `skills/beads-upstream/` exists with a frontmatter-valid `SKILL.md` (description carrying intent-triggers + SKIP), `README.md`, `init` + push + status/pull procedures; backend `none` (fully-disabled) is a valid init choice that makes push/status no-op and the close-time trigger silent; GitHub path dry-run-verified; GitLab/Jira config stubs present and labelled. A pruned companion rule `protocols/UPSTREAM_TRACKING.md` (close-time push trigger honoring the disabled flag + never-bare-sync invariant + SKILL pointer) ships with a hash-stamped `manifest.json`; auto-discovered by `install.sh`; added to project `README.md`. `CONSISTENCY.md` sub-agent returns no unresolved FAIL.
+3. `beads-extra` has the corrects-the-plugin callout, a 1.0.5-correct `-t` list, and taxonomy citations; `beads-authoring` taxonomy references are citations; both READMEs synced; `CONSISTENCY.md` clean.
+4. All changes committed; relevant `gh issue`s filed/closed; `git push` succeeds and `git status` is clean.

--- a/docs/plans/plan-003-james-dixson-adacc7/reviews/pass-1.md
+++ b/docs/plans/plan-003-james-dixson-adacc7/reviews/pass-1.md
@@ -1,0 +1,37 @@
+# Review Pass 1 — plan-003-james-dixson-adacc7
+
+**Date:** 2026-06-01
+**Reviewer:** bdplan reviewer agent (red-team, read-only)
+**Verdict:** REVISE → concerns resolved in place (revised plan ready for operator approval)
+
+## Verdict rationale
+
+Plan well-scoped; three epics genuinely decoupled; dependency graph structurally sound (entry leaves of Epics 2 & 3 gated on start-gate; all dep edges task→task within an epic, no task-blocks-epic violation). The "utility skill, not formula/coordinator" call for `beads-upstream` was confirmed correct (no work-bead DAG to pour). Two factual contradictions + several missing edge cases required a revision pass; no re-investigation needed.
+
+## Concerns and resolutions
+
+1. **(high) `-t` list claim was wrong.** Reviewer: `beads-extra/SKILL.md:29` already lists `…|molecule|gate|event`; real gap is missing `decision` + likely-erroneous `molecule|event`, not "missing decision."
+   **Resolution:** Verified authoritative enum `bug|feature|task|epic|chore|decision` against `bd create --help`. Rewrote Investigation Findings `-t` bullet and Issue 3.2: add `decision`, remove `molecule`, annotate `gate` (via `bd gate create`) / `event` (via `--type=event`) special paths. Build-time isolated-DB probe added.
+
+2. **(med) "Wire into install.sh" is a no-op.** Reviewer: `install.sh` auto-discovers `skills/*/` with a `SKILL.md`; companion rules ship via `protocols/*.md` + `manifest.json`.
+   **Resolution:** Verified (`install.sh:112` discovery loop; `install_rules` at :90; bdplan/bdresearch ship `protocols/`). Rewrote Issue 2.7 — no install.sh edit; companion rule only if always-loaded behavior needed; clarified in 2.2 that the project `UPSTREAM_TRACKING.md` is init-generated into the target project, distinct from a shipped companion rule.
+
+3. **(med) Push step lacked auth + partial-push failure handling.**
+   **Resolution:** Issue 2.3 now requires pre-flight auth check, partial-failure re-enumeration + error surfacing (no swallowing).
+
+4. **(med) External-mapping idempotency asserted but deferred.**
+   **Resolution:** Promoted the dry-run + real-scoped-push idempotency probe into Issue 2.3 as a completion-gating checkpoint; if `--push-only --issues` doesn't record the mapping like bare `sync`, recovery story is redesigned before 2.3 is done. Added a dedicated risk row.
+
+5. **(low) M2 split should cite the global portability rule as its reason.**
+   **Resolution:** Issue 1.1 now states the rationale — `bd remember` is project-DB-local / not in JSONL export, so must not be promoted to durable/portable use; durable knowledge stays in `AGENTS/` rules or upstreamed beads.
+
+### Missing items addressed
+
+- **`dolt.local-only` already-configured guard** → added to Issue 2.2 (confirm before flipping if a remote exists).
+- **Build-time test repo lifecycle** → risk row now specifies a throwaway GitHub repo under the operator's account, created for the test and torn down after.
+- **GitLab/Jira stub flag-shape** → Issue 2.5 now cites the verified backend-generic flag finding rather than asserting.
+- **Epic 1 governing check** = `optimal-instructions` (not `CONSISTENCY.md`, which governs skill dirs) — already named in 1.3; noted correct.
+
+## Final status
+
+All concerns resolved by in-place revision. Plan returned to `drafting` pending operator approval. No INVESTIGATE-MORE triggered.

--- a/skills/beads-authoring/SKILL.md
+++ b/skills/beads-authoring/SKILL.md
@@ -268,6 +268,11 @@ All task tracking inside a beads-backed skill MUST use `bd`. Never use TodoWrite
 markdown checklists, or inline task lists. Sub-work discovered during execution creates
 new beads with `--deps discovered-from:<parent-id>`.
 
+For the dependency-type semantics behind `discovered-from` / `blocks` / `related` /
+`parent-child`, and the AI-supervised issue lifecycle these skills orchestrate, cite the
+plugin's stable `resources/DEPENDENCIES.md` and `resources/WORKFLOWS.md` rather than
+restating them — this skill owns only the authoring conventions layered on top.
+
 ## bd idioms in skill code
 
 - **Null-guard every `jq -r '.id'` from a `bd ... --json` write.** Use `// empty` and
@@ -317,4 +322,6 @@ Convention** — preflight, config/state, manifest-hashed companion rules), then
 - **`beads`** — the canonical routine `bd` loop.
 - **`beads-extra`** — direct-CLI gotchas (issue types, gates, dep mutation, defensive
   JSON, `bd batch`, `bd mol pour` output shape) that this skill's runtime steps depend on.
+- **Plugin `resources/`** — canonical taxonomy cited above: `DEPENDENCIES.md` (the four
+  dependency types) and `WORKFLOWS.md` (the AI-supervised issue lifecycle).
 - **`bdplan`** / **`bdresearch`** — complete worked examples of these conventions.

--- a/skills/beads-extra/SKILL.md
+++ b/skills/beads-extra/SKILL.md
@@ -24,13 +24,35 @@ parts that bite when you script `bd` directly.
 > lines (steveyegge/beads ≤ 0.x) no longer hold; where behavior is version-sensitive it
 > is called out inline. Re-verify against your installed `bd version` if it differs.
 
+> **Corrects the bundled `beads` plugin docs.** The installed `beads` plugin ships
+> pre-1.0.5 (0.60.0/ACF-era) `resources/` that are wrong for 1.0.5 — **this skill wins**
+> where they disagree:
+> - `resources/ASYNC_GATES.md` — uses `bd gate approve` / `bd gate eval` / `bd gate close`.
+>   None exist in 1.0.5; the gate verbs are `add-waiter | check | create | discover | list
+>   | resolve | show` (resolve a gate with `bd gate resolve`, see Gates below).
+> - `resources/CHEMISTRY_PATTERNS.md` — uses bare `bd pour` / `bd wisp` (both
+>   `unknown command` in 1.0.5; the real verbs are `bd mol pour` / `bd mol wisp`) and
+>   `bd mol catalog` (no such verb — list formulas with `bd formula list`).
+
 ## Issue types accepted by `bd create -t`
 
-`bug | feature | task | epic | chore | molecule | gate | event`.
+`bd create --help` advertises the normal-work enum: `bug | feature | task | epic | chore |
+decision` (aliases: `enhancement`/`feat`→`feature`, `dec`/`adr`→`decision`). Custom types
+require `types.custom` config.
 
-- **`gate` is first-class** in 1.0.5 — `bd create "Gate: …" -t gate` succeeds and the
-  result is a real gate (`bd gate …`, `bd gate resolve` apply). You do **not** need the
-  old `-t task` + `Gate:`-prefix workaround.
+The binary **also** accepts three built-in types that are not ordinary work items — each
+has a dedicated creation path, and a `molecule` or resolved-`gate` bead does **not** surface
+in `bd ready`:
+
+- **`gate`** — `bd create "Gate: …" -t gate` succeeds and yields a real gate (`bd gate …`,
+  `bd gate resolve` apply); no old `-t task` + `Gate:`-prefix workaround needed. Canonical
+  path: `bd gate create` or a formula `gate` step (see Gates below).
+- **`event`** — create with `--type=event` plus the `--event-*` flags (`--event-actor`,
+  `--event-category`, `--event-target`, `--event-payload`).
+- **`molecule`** — the chemistry container, normally created by `bd mol pour`, not by hand.
+
+Verified on 1.0.5: `-t decision|gate|event|molecule` each create a bead of that type; an
+unknown type (`-t bananafone`) is rejected with `invalid issue type`.
 
 ## Gates
 
@@ -51,6 +73,11 @@ Gate types reported by `bd gate --help`: `human` (resolve via `bd gate resolve` 
 `human`.
 
 ## Dependency-edge mutation
+
+For what the four dependency types **mean** (`blocks` / `related` / `parent-child` /
+`discovered-from` — only `blocks` gates readiness), see the plugin's canonical
+`resources/DEPENDENCIES.md`. This section covers only the edge **mutation** mechanics and
+1.0.5 gotchas that doc omits.
 
 - **Add an edge with `bd dep` — it is additive.** Either form works and neither drops
   existing edges:
@@ -185,3 +212,7 @@ gates without re-discovering them. (`bd mol wisp` is the ephemeral/vapor equival
 - **`beads-authoring`** — conventions for *building* beads-backed skills (formulas,
   coordinator loops, the `coordinate` subcommand). This skill is runtime CLI usage;
   that one is authoring.
+- **Plugin `resources/`** — canonical, stable taxonomy this skill cites rather than
+  restates: `DEPENDENCIES.md` (the four dependency types) and `WORKFLOWS.md` (the
+  AI-supervised issue lifecycle). Where the plugin's older `ASYNC_GATES.md` /
+  `CHEMISTRY_PATTERNS.md` disagree with 1.0.5, this skill wins (see the callout above).

--- a/skills/beads-upstream/README.md
+++ b/skills/beads-upstream/README.md
@@ -1,0 +1,70 @@
+---
+title: beads-upstream
+created: '2026-06-01'
+tags: []
+---
+
+# beads-upstream
+
+Configurable, GitHub-first upstream-tracking skill for beads. Pushes open/deferred beads to
+an issue tracker (GitHub/GitLab/Jira) as a land-the-plane step, and enumerates upstream issues
+as the authoritative worklist on status/pull. A **utility skill** — no formula, `bd mol pour`,
+or coordinator loop.
+
+## Prerequisites
+
+- `bd` (beads) >= 1.0.5 — provides first-class `bd github` / `bd gitlab` / `bd jira` sync.
+- For the GitHub backend: the `gh` CLI authenticated (`gh auth status`), used to mint an inline
+  token (`gh auth token`).
+- `uv` — runs the `scripts/` Python helper (PEP 723 inline deps).
+- `git` — remote-URL detection during `init`.
+
+## Install
+
+Installed by the repo-level `install.sh`, which auto-discovers every `skills/*/` directory. The
+skill ships one **companion rule** (`protocols/UPSTREAM_TRACKING.md`) that `install.sh` surfaces
+to the install's rules dir (always-loaded), and **no hook**. No install changes needed. See the
+project [README](../../README.md) for `install.sh` flags.
+
+## Usage
+
+User-invocable (`/beads-upstream`). Operations:
+
+- `/beads-upstream init` — detect git remote → propose backend (`github|gitlab|jira|none`) →
+  write `<backend>.*` config. `none` fully disables upstream tracking (a first-class, re-enableable choice).
+- `/beads-upstream` (push) — land-the-plane: push open/deferred beads upstream (scoped, dry-run-first).
+- `/beads-upstream status` — enumerate the upstream worklist (or fall back to local `bd` when disabled).
+
+The **close-time / land-the-plane push trigger** is not invoked by intent language; it is bound
+by the always-loaded companion rule `protocols/UPSTREAM_TRACKING.md`.
+
+## Behavior model
+
+No phase model (utility skill). Three independent operations, each honoring the disabled (`none`) flag:
+
+```
+init     → detect remote → propose backend → bd config set <backend>.* (or custom.upstream.enabled=false)
+push     → read config → disabled? no-op : enumerate open/deferred → --dry-run scoped push → confirm → push → record External: map
+status   → read config → disabled? local bd ready/list : enumerate upstream issues as worklist
+```
+
+Safety invariant (everywhere): never a bare `bd <backend> sync`; always `--push-only` + scoped
+`--issues`/`--parent` + `--dry-run` first. Auth is inline-only, never persisted.
+
+## Layout
+
+```
+skills/beads-upstream/
+├── SKILL.md                       # entry point: trigger split, backends, init/push/status, safety invariants
+├── README.md                      # this file
+├── protocols/
+│   ├── UPSTREAM_TRACKING.md       # always-loaded companion rule (close-time trigger + safety invariant)
+│   └── manifest.json              # hash/version manifest for UPSTREAM_TRACKING.md
+├── scripts/
+│   ├── upstream.py                # enumerate open/deferred beads + parse External: mappings (uv/PEP723)
+│   └── manifest_update.py         # recompute manifest hashes + bump versions (vendored)
+└── spec/
+    ├── operations.md              # init/push/status behavioral contract (REQ-OP-*)
+    ├── safety.md                  # never-bare-sync, inline auth, idempotency, disabled no-op (REQ-SAFE-*)
+    └── backends.md                # backend coverage, flag divergence, trigger split (REQ-BE-*)
+```

--- a/skills/beads-upstream/SKILL.md
+++ b/skills/beads-upstream/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: beads-upstream
+description: >
+  Configurable, GitHub-first upstream-tracking skill for beads. Pushes open/deferred
+  beads to an issue tracker (GitHub/GitLab/Jira) as a land-the-plane step, and enumerates
+  upstream issues as the authoritative worklist on status/pull.
+  TRIGGER when: /beads-upstream invoked; "set up upstream tracking" / "configure upstream"
+  (init); "push beads upstream" / "push open work to GitHub"; asking for project status,
+  available work, or the worklist when upstream tracking is configured (status/pull).
+  SKIP for: routine local `bd ready` / `bd show` / `bd close` (use `beads`); direct-CLI
+  `bd` scripting gotchas (use `beads-extra`); authoring beads-backed skills
+  (use `beads-authoring`). The close-time / land-the-plane push trigger is NOT carried in
+  this description — it lives in the always-loaded companion rule (protocols/UPSTREAM_TRACKING.md).
+user-invocable: true
+allowed-tools:
+  - Read
+  - Bash
+  - Write
+  - Edit
+  - AskUserQuestion
+---
+
+# beads-upstream
+
+A **utility skill** (no formula / `bd mol pour` / coordinator) that binds a beads workspace
+to an upstream issue tracker. It owns three operations: `init` (configure a backend), the
+**push step** (land-the-plane: push open/deferred beads upstream), and **status/pull**
+(treat upstream issues as the worklist). GitHub is fully implemented; GitLab/Jira ship as
+config-only stubs sharing the same verb shape.
+
+Built on bd 1.0.5's first-class `bd github` / `bd gitlab` / `bd jira` upstream sync. For the
+`bd` CLI gotchas these steps rely on (defensive `--json` parsing, issue-type semantics) see
+`beads-extra`.
+
+## SKILL_DIR
+
+```bash
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo .)
+SKILL_DIR=$(find ~/.claude/skills ~/.agents/skills "$GIT_ROOT/.claude/skills" "$GIT_ROOT/.agents/skills" .claude/skills .agents/skills -maxdepth 1 -name beads-upstream -type d 2>/dev/null | head -1)
+[ -z "$SKILL_DIR" ] && { echo "ERROR: beads-upstream skill directory not found"; exit 1; }
+```
+
+All skill-internal paths use `${SKILL_DIR}/` prefix.
+
+## Trigger split (the load-bearing design)
+
+Two distinct trigger classes, deliberately routed to two different surfaces:
+
+- **Intent triggers → this SKILL's `description`.** `init`, `status`/pull, "set up upstream
+  tracking", "push beads upstream". Description-matching catches these reliably because the
+  user states the intent.
+- **Procedural trigger → the always-loaded companion rule** (`protocols/UPSTREAM_TRACKING.md`,
+  installed to the rules surface). The push-at-session-close / land-the-plane step is *not*
+  reliably caught by a description — nobody says "trigger the upstream skill" when wrapping
+  up — so the rule binds it and is in context every turn. The rule is minimal: the close-time
+  trigger + the one safety invariant + a pointer here. All procedure lives in this SKILL.
+
+## Backends
+
+| Backend  | Config namespace                         | Status      |
+|----------|------------------------------------------|-------------|
+| `github` | `github.owner` / `github.repo` / token   | implemented, dry-run-tested |
+| `gitlab` | `gitlab.*`                               | config-only stub (unverified) |
+| `jira`   | `jira.*`                                 | config-only stub (unverified; field model differs) |
+| `none`   | `custom.upstream.enabled=false`          | first-class: upstream tracking fully disabled |
+
+Auth is always passed **inline, never persisted**: `TOKEN=$(...) bd <backend> sync …`.
+
+## `/beads-upstream init`
+
+Configure the backend only. `init` does **not** write any rule file into the project — the
+trigger contract ships as this skill's companion rule (installed by `install.sh`).
+
+### 1 — Detect the remote and propose a backend
+
+```bash
+REMOTE_URL=$(git config --get remote.origin.url 2>/dev/null)
+```
+
+- `github.com` → propose `github`; `gitlab.*` → propose `gitlab`; otherwise propose `none`.
+- Parse `owner`/`repo` from the URL (`…/<owner>/<repo>(.git)`).
+
+### 2 — Confirm with the operator
+
+Use `AskUserQuestion`: backend = `github` | `gitlab` | `jira` | `none` (detected default first).
+`none` is a first-class choice — upstream tracking fully disabled.
+
+### 3 — Write config
+
+**GitHub** (analogous keys for `gitlab.*` / `jira.*`):
+
+```bash
+bd config set github.owner "<owner>"
+bd config set github.repo  "<repo>"
+bd config set custom.upstream.enabled true
+bd config set custom.upstream.backend github
+```
+
+Never write a token to config. Auth is inline at call time: `GITHUB_TOKEN=$(gh auth token) bd github …`.
+
+**`none`** — write an explicit *opted-out* marker (not merely unconfigured), so push/status
+no-op and the close-time rule trigger stays silent; re-running `init` can re-enable:
+
+```bash
+bd config set custom.upstream.enabled false
+bd config set custom.upstream.backend none
+```
+
+### 4 — `dolt.local-only` guard
+
+Upstream tracking assumes the dolt DB is local-only (issues live upstream, not in a dolt remote).
+Before flipping it, detect an existing remote — the operator may run one intentionally:
+
+```bash
+bd config get dolt.local-only          # current value
+bd dolt remote list                    # any configured remote?
+```
+
+If a dolt remote **is** configured, confirm with the operator before `bd config set dolt.local-only true`.
+If none, set it. Skip the flip entirely for backend `none`.
+
+## Push step (land-the-plane)
+
+Push **open + deferred** beads (blocked, descoped, discovered-but-not-done, follow-ups) upstream
+as the session/plan closes. Closed beads are never pushed.
+
+### 0 — Disabled short-circuit (first, always)
+
+```bash
+bd config get custom.upstream.enabled
+```
+
+If `false` / backend `none`: report "upstream tracking disabled" and **exit 0**. No enumeration,
+no prompt, no upstream call.
+
+### 1 — Auth pre-flight
+
+Verify the token resolves **before** any push; fail fast on empty/expired:
+
+```bash
+GITHUB_TOKEN=$(gh auth token 2>/dev/null)
+[ -z "$GITHUB_TOKEN" ] && { echo "ERROR: no GitHub token (run: gh auth login)"; exit 1; }
+```
+
+### 2 — Enumerate candidates
+
+```bash
+uv run ${SKILL_DIR}/scripts/upstream.py enumerate --json   # open+blocked+deferred, not-yet-mapped
+```
+
+The helper (see `scripts/upstream.py`) lists candidate bead IDs and flags those already carrying
+an `External:` mapping (parsed defensively per `beads-extra`). Present the set; the operator
+confirms the scoped IDs.
+
+### 3 — Dry-run, then scoped push
+
+Use the dedicated `bd github push` (≡ `bd github sync --push-only --issues <ids>`); **never a bare
+`bd github sync`**:
+
+```bash
+GITHUB_TOKEN=$(gh auth token) bd github push <id1> <id2> … --dry-run   # confirm only intended beads
+GITHUB_TOKEN=$(gh auth token) bd github push <id1> <id2> …             # real push
+```
+
+(For a whole subtree: `bd github sync --push-only --parent <id> --dry-run`.) After a successful
+push, bd records the new issue URL on each bead as a single `External:` line in `bd show <id>`:
+
+```
+External: https://github.com/<owner>/<repo>/issues/<N>
+```
+
+This mapping is what suppresses duplicate creation on re-push (verified live on 1.0.5 — see step 5).
+
+### 4 — Partial-push / failure handling
+
+On non-zero `bd github push` exit: re-enumerate `External:` mappings, report **pushed-vs-remaining**
+beads, and surface (never swallow) the error:
+
+```bash
+uv run ${SKILL_DIR}/scripts/upstream.py mappings --issues <id1>,<id2>,… --json
+```
+
+Do not blind-retry — a re-run on already-mapped beads is safe (step 5) but must be a *deliberate*
+re-push of the remaining set, not a bare sync.
+
+### 5 — Idempotency checkpoint (gates this step)
+
+A re-push of an already-mapped bead must **not** create a duplicate upstream issue. This rests on
+bd recording the `External:` mapping and suppressing re-push for mapped beads. **Verify on the live
+binary against a throwaway repo before relying on it** (see `spec/` / the build-time check): dry-run
++ real scoped push of a fresh bead, then re-push the same bead and confirm no second issue. If
+`bd github push` does not record the mapping the way bare `sync` does, redesign the recovery story
+before trusting re-push.
+
+> **Verified (bd 1.0.5, throwaway repo, 2026-06-01):** `bd github push <id>` records
+> `External: …/issues/N` on the bead; a second `bd github push <id>` left the upstream issue count
+> at 1 (no duplicate — it updates the mapped issue). The dedicated `push` subcommand records the
+> mapping identically to bare `sync`, so scoped re-push is safe for partial-failure recovery.
+
+## Status / pull
+
+First read the config (`bd config get custom.upstream.enabled`).
+
+**Disabled (`none` / `enabled=false`):** report "upstream tracking disabled" and fall back to
+the local worklist — `bd ready` (unblocked) then `bd list --status open` (full inventory). No
+upstream calls.
+
+**Enabled:** the upstream tracker is the authoritative worklist (the local bead set may be
+stale). Enumerate open upstream issues, ordered by labels/priority:
+
+```bash
+gh issue list --repo "<owner>/<repo>" --state open \
+  --json number,title,labels,url --jq 'sort_by(.labels)'
+```
+
+Order the execution sequence by the issues' labels (severity/priority, `bug` before
+`enhancement`, blocked-by relationships). Local beads are a convenience view over this list.
+`bd github status` shows sync state (config + last-sync) but is not the worklist.
+
+(GitLab/Jira: substitute `glab issue list` / Jira JQL — see Backend generalization.)
+
+## Backend generalization
+
+GitHub is the implemented, dry-run-and-live-tested path (see Push step step 5). GitLab and
+Jira are **config-only stubs** — the config keys and verb shape are wired, but no push has
+been exercised against a live GitLab/Jira instance. Do not present them as tested.
+
+All three backends expose `push` / `pull` / `status` / `sync` subcommands. Scoped-push
+translation (verified against `bd <backend> sync --help` on 1.0.5):
+
+| Step          | GitHub                              | GitLab                              | Jira (unverified)                          |
+|---------------|-------------------------------------|-------------------------------------|--------------------------------------------|
+| Config        | `github.owner` / `github.repo`      | `gitlab.*` (+ `--project` group id) | `jira.*`                                    |
+| Scoped push   | `bd github push <ids>`              | `bd gitlab push <ids>`              | `bd jira push <ids>`                        |
+| ≡ sync form   | `sync --push-only --issues <ids>`   | `sync --push-only --issues <ids>`   | `sync --push --issues <ids>` ⚠             |
+| Subtree push  | `sync --push-only --parent <id>`    | `sync --push-only --parent <id>`    | `sync --push --parent <id>` ⚠              |
+| Dry-run       | `--dry-run`                         | `--dry-run`                         | `--dry-run`                                 |
+
+⚠ **Jira divergence:** `bd jira sync` uses `--push` / `--pull` (not `--push-only` /
+`--pull-only`) and adds `--create-only` for new-issues-only. Jira's field model (projects,
+issue types, required fields) differs from GitHub/GitLab labels — the stub is unverified and
+will likely need field mapping before a real push. Prefer the dedicated `bd jira push <ids>`
+subcommand, which mirrors the others' positional-IDs shape.
+
+The `--issues` / `--parent` / `--dry-run` flags are confirmed present on backend-generic
+`bd <backend> sync` for all three (plan-003 Investigation Finding; re-verified here via
+`bd <backend> sync --help`). The never-bare-`sync` invariant applies to every backend.
+
+## Safety invariants
+
+- **Never run a bare `bd <backend> sync`.** A bare sync re-imports every upstream issue as a
+  duplicate bead and pushes the entire local DB (closed epics, gates, dupes) upstream. Always
+  `--push-only` + scoped `--issues <ids>` (or `--parent <id>`), `--dry-run` first.
+- **Auth is inline-only.** `TOKEN=$(...) bd <backend> sync …` — never write a token to config.
+- **Disabled (`none`) is honored everywhere.** Push and status no-op cleanly; the close-time
+  rule trigger is a silent no-op.
+
+## See also
+
+- **`beads`** — the canonical routine `bd` loop.
+- **`beads-extra`** — defensive `--json` parsing, issue-type/gate semantics this skill relies on.
+- **companion rule** `protocols/UPSTREAM_TRACKING.md` — the always-loaded close-time trigger.
+  After editing it, restamp the hash: `uv run ${SKILL_DIR}/scripts/manifest_update.py ${SKILL_DIR}/protocols`.

--- a/skills/beads-upstream/protocols/UPSTREAM_TRACKING.md
+++ b/skills/beads-upstream/protocols/UPSTREAM_TRACKING.md
@@ -1,0 +1,23 @@
+# Upstream Tracking Protocol
+
+Always-loaded trigger contract for the `beads-upstream` skill. Procedure (init, backends,
+auth, failure handling) lives in the skill's `SKILL.md`; this rule binds only what a
+description cannot reliably catch.
+
+## Close-time push trigger
+
+On push-like operations, session or plan close, or "land the plane": invoke `/beads-upstream`
+to push **open + deferred** beads (blocked, descoped, discovered-but-not-done, follow-ups)
+upstream before the session ends.
+
+**Unless upstream tracking is disabled** (`custom.upstream.enabled=false` / backend `none`),
+in which case this trigger is a **silent no-op** — do not enumerate, prompt, or nag.
+
+## Safety invariant
+
+Never run a bare `bd <backend> sync` — it re-imports every upstream issue as a duplicate bead
+and pushes the whole local DB upstream. Always `--push-only` (Jira: `--push`) + scoped
+`--issues <ids>` / `--parent <id>`, and `--dry-run` first. Auth is inline-only
+(`TOKEN=$(...) bd <backend> …`), never written to config.
+
+For config, backends, and failure handling, see the `beads-upstream` SKILL.

--- a/skills/beads-upstream/protocols/manifest.json
+++ b/skills/beads-upstream/protocols/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "files": {
+    "UPSTREAM_TRACKING.md": {
+      "sha256": "075a077c98c1e780a75fe4fc7d156a6cbe1df118f2bcbf9c4dba38c797db6e31",
+      "version": "1.0.0",
+      "deprecated": false,
+      "previous_versions": []
+    }
+  }
+}

--- a/skills/beads-upstream/scripts/manifest_update.py
+++ b/skills/beads-upstream/scripts/manifest_update.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Recompute hashes + bump versions in a skill's protocols/manifest.json.
+
+Reads `<protocols-dir>/manifest.json`, recomputes sha256 for each declared
+file, and on change appends the prior entry to `previous_versions[]` and
+bumps the semver. Writes back atomically.
+
+Per the Skill Surface Convention
+(skill-authoring/reference/SURFACE_CONVENTION.md § 2 "Hash manifest").
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+SCHEMA_VERSION = 1
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def bump(version: str, level: str) -> str:
+    parts = version.split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        raise SystemExit(f"manifest_update: version {version!r} is not MAJOR.MINOR.PATCH")
+    major, minor, patch = (int(p) for p in parts)
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def atomic_write(path: Path, data: str) -> None:
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(data)
+        os.replace(tmp, path)
+    except Exception:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def update_manifest(protocols_dir: Path, level: str, dry_run: bool) -> Tuple[int, list[str]]:
+    manifest_path = protocols_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise SystemExit(f"manifest_update: {manifest_path} does not exist")
+
+    manifest = json.loads(manifest_path.read_text())
+    schema = manifest.get("schema_version")
+    if schema != SCHEMA_VERSION:
+        raise SystemExit(
+            f"manifest_update: schema_version {schema!r} unsupported (this helper speaks v{SCHEMA_VERSION})"
+        )
+
+    files = manifest.setdefault("files", {})
+    changes: list[str] = []
+
+    for fname, entry in files.items():
+        target = protocols_dir / fname
+        if not target.exists():
+            raise SystemExit(f"manifest_update: declared file {fname!r} is missing from {protocols_dir}")
+        new_hash = sha256_file(target)
+        old_hash = entry.get("sha256")
+        old_version = entry.get("version", "0.0.0")
+        if old_hash == new_hash:
+            continue
+        prev = entry.setdefault("previous_versions", [])
+        if old_hash:
+            prev.append({"sha256": old_hash, "version": old_version})
+        entry["sha256"] = new_hash
+        entry["version"] = bump(old_version, level)
+        entry.setdefault("deprecated", False)
+        changes.append(f"{fname}: {old_version} -> {entry['version']} ({old_hash[:8] if old_hash else 'new'} -> {new_hash[:8]})")
+
+    if changes and not dry_run:
+        atomic_write(manifest_path, json.dumps(manifest, indent=2) + "\n")
+
+    return len(changes), changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Recompute hashes + bump versions in a skill's protocols/manifest.json."
+    )
+    parser.add_argument(
+        "protocols_dir",
+        type=Path,
+        help="path to the skill's protocols/ directory (must contain manifest.json)",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--minor", action="store_true", help="bump minor instead of patch")
+    group.add_argument("--major", action="store_true", help="bump major instead of patch")
+    parser.add_argument("--dry-run", action="store_true", help="report changes without writing")
+    args = parser.parse_args()
+
+    level = "major" if args.major else "minor" if args.minor else "patch"
+    count, changes = update_manifest(args.protocols_dir.resolve(), level, args.dry_run)
+
+    if count == 0:
+        print("manifest_update: no changes (all hashes match)")
+        return 0
+    verb = "would update" if args.dry_run else "updated"
+    print(f"manifest_update: {verb} {count} entry/entries:")
+    for c in changes:
+        print(f"  - {c}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/beads-upstream/scripts/upstream.py
+++ b/skills/beads-upstream/scripts/upstream.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""beads-upstream helper: enumerate push candidates and read External: mappings.
+
+Two subcommands the SKILL.md push step calls:
+
+  enumerate [--json]            List open+blocked+deferred beads (push candidates),
+                                flagging those that already carry an upstream
+                                `External:` mapping.
+  mappings --issues <csv> [--json]
+                                For each bead ID, report its `External:` upstream
+                                URL (or null if unmapped).
+
+`bd list --json` may be a multi-document array and may carry warning prefixes on
+stdout; we parse defensively (see the `beads-extra` skill → defensive JSON). The
+upstream mapping is read from `bd show <id>` text — a single line anchored as
+`External: <url>` — verified stable on bd 1.0.5.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+CANDIDATE_STATUSES = "open,blocked,deferred"
+# Anchored: real mapping line starts the line and is a URL — avoids matching the
+# word "External:" inside a description body.
+EXTERNAL_RE = re.compile(r"^\s*External:\s*(https?://\S+)", re.MULTILINE)
+
+
+def run(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(f"command failed ({proc.returncode}): {' '.join(cmd)}")
+    return proc.stdout
+
+
+def parse_json_array(text: str) -> list[dict]:
+    """Defensive parse of `bd ... --json`. Returns a list of issue dicts.
+
+    Tolerates a warning prefix before the JSON and both shapes (top-level array,
+    or {"issues":[...]}/single object). Falls back to extracting the first
+    balanced [...] / {...} block if a direct load fails.
+    """
+    for candidate in (text, _first_balanced(text)):
+        if not candidate:
+            continue
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return data.get("issues", [data])
+    return []
+
+
+def _first_balanced(text: str) -> str | None:
+    open_ch = None
+    for opener, closer in (("[", "]"), ("{", "}")):
+        i = text.find(opener)
+        if i != -1 and (open_ch is None or i < open_ch[1]):
+            open_ch = (opener, i, closer)
+    if open_ch is None:
+        return None
+    opener, start, closer = open_ch
+    depth = 0
+    for j in range(start, len(text)):
+        if text[j] == opener:
+            depth += 1
+        elif text[j] == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start : j + 1]
+    return None
+
+
+def external_for(bead_id: str) -> str | None:
+    out = run(["bd", "show", bead_id])
+    m = EXTERNAL_RE.search(out)
+    return m.group(1) if m else None
+
+
+def cmd_enumerate(as_json: bool) -> int:
+    rows = parse_json_array(run(["bd", "list", "--status", CANDIDATE_STATUSES, "--json"]))
+    # Skip container types — only push real work items.
+    rows = [r for r in rows if r.get("issue_type") not in ("epic", "molecule", "gate")]
+    out = []
+    for r in rows:
+        bid = r.get("id")
+        if not bid:
+            continue
+        ext = external_for(bid)
+        out.append(
+            {
+                "id": bid,
+                "title": r.get("title", ""),
+                "status": r.get("status", ""),
+                "type": r.get("issue_type", ""),
+                "mapped": ext is not None,
+                "external": ext,
+            }
+        )
+    if as_json:
+        print(json.dumps(out, indent=2))
+    else:
+        unmapped = [r for r in out if not r["mapped"]]
+        print(f"{len(out)} candidate(s) (open/blocked/deferred); {len(unmapped)} not yet mapped:")
+        for r in out:
+            flag = r["external"] if r["mapped"] else "—"
+            print(f"  {r['id']:<16} [{r['status']}/{r['type']}] {r['title']}  ({flag})")
+    return 0
+
+
+def cmd_mappings(issues_csv: str, as_json: bool) -> int:
+    ids = [s.strip() for s in issues_csv.split(",") if s.strip()]
+    out = [{"id": bid, "external": external_for(bid)} for bid in ids]
+    if as_json:
+        print(json.dumps(out, indent=2))
+    else:
+        for r in out:
+            print(f"  {r['id']:<16} {r['external'] or '(unmapped)'}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="beads-upstream push helpers.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_enum = sub.add_parser("enumerate", help="list open/blocked/deferred push candidates")
+    p_enum.add_argument("--json", action="store_true", dest="as_json")
+
+    p_map = sub.add_parser("mappings", help="report External: mappings for given bead IDs")
+    p_map.add_argument("--issues", required=True, help="comma-separated bead IDs")
+    p_map.add_argument("--json", action="store_true", dest="as_json")
+
+    args = parser.parse_args()
+    if args.cmd == "enumerate":
+        return cmd_enumerate(args.as_json)
+    if args.cmd == "mappings":
+        return cmd_mappings(args.issues, args.as_json)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/beads-upstream/spec/backends.md
+++ b/skills/beads-upstream/spec/backends.md
@@ -1,0 +1,26 @@
+# Spec: Backends & trigger split
+
+## Requirements
+
+- **REQ-BE-001:** GitHub is the implemented, dry-run-and-live-tested backend. GitLab and Jira are
+  config-only stubs and must not be presented as tested. — *Rationale:* honesty about coverage.
+  — *Verify:* SKILL.md "Backend generalization" §.
+
+- **REQ-BE-002:** Backend-generic scoped-push flags `--issues` / `--parent` / `--dry-run` are present
+  on `bd github|gitlab|jira sync`; Jira diverges by using `--push`/`--pull` (not `--push-only`) and
+  `--create-only`. — *Rationale:* the translation table must reflect the real CLI, not assume uniformity.
+  — *Verify:* `bd github|gitlab|jira sync --help`; SKILL.md backend table.
+
+- **REQ-BE-003:** All four backend states are first-class, including `none` (fully disabled,
+  re-enableable). — *Rationale:* disabling is a supported configuration, not an error state.
+  — *Verify:* SKILL.md Backends table; REQ-OP-003.
+
+- **REQ-BE-004 (trigger split):** Intent triggers (`init`, `status`/pull, "set up upstream tracking",
+  "push beads upstream") live in the SKILL `description`; the procedural close-time/land-the-plane
+  push trigger lives only in the always-loaded companion rule, never in the description. — *Rationale:*
+  a description cannot reliably catch "wrapping up"; an always-loaded rule can. — *Verify:* SKILL.md
+  frontmatter description + "Trigger split" §; protocols/UPSTREAM_TRACKING.md.
+
+- **REQ-BE-005:** This is a utility skill — no formula, `bd mol pour`, or coordinator loop. — *Rationale:*
+  the work is config + scoped CLI calls, not a multi-bead DAG. — *Verify:* absence of `formulas/`,
+  `bd mol pour` in SKILL.md.

--- a/skills/beads-upstream/spec/operations.md
+++ b/skills/beads-upstream/spec/operations.md
@@ -1,0 +1,37 @@
+# Spec: Operations
+
+The three operations beads-upstream owns. Source of truth for the skill's behavioral contract.
+
+## Requirements
+
+- **REQ-OP-001:** `init` detects the git remote, proposes a backend (`github` from `github.com`,
+  `gitlab` from `gitlab.*`, else `none`), confirms via `AskUserQuestion`, and writes config with
+  `bd config set`. — *Rationale:* one consent-gated setup path. — *Verify:* SKILL.md "/beads-upstream init" §; `bd config set --help`.
+
+- **REQ-OP-002:** `init` writes no rule file into the target project; the trigger contract ships
+  only as the skill's installed companion rule. — *Rationale:* the rule is installer-managed, not
+  init-managed (Surface Convention). — *Verify:* SKILL.md init §; absence of any rule-write in init steps.
+
+- **REQ-OP-003:** Selecting backend `none` writes an explicit opted-out marker
+  (`custom.upstream.enabled=false`, `custom.upstream.backend=none`), not merely leaving config unset;
+  re-running `init` can re-enable. — *Rationale:* opted-out ≠ unconfigured; distinguishes "off on
+  purpose" from "never set up." — *Verify:* SKILL.md init step 3.
+
+- **REQ-OP-004:** The push step short-circuits to a clean exit 0 (no enumeration, prompt, or upstream
+  call) when tracking is disabled. — *Rationale:* opted-out projects are never nagged. — *Verify:*
+  SKILL.md push step 0; protocols/UPSTREAM_TRACKING.md no-op clause.
+
+- **REQ-OP-005:** The push step pushes only **open + deferred** work (open, blocked, deferred);
+  never closed beads; epics/molecules/gates excluded as non-work. — *Rationale:* only unfinished work
+  belongs upstream. — *Verify:* `upstream.py` `CANDIDATE_STATUSES` + type filter; SKILL.md push intro.
+
+- **REQ-OP-006:** The push step verifies the auth token resolves before any push and fails fast on
+  empty/expired. — *Rationale:* fail before side effects, not during. — *Verify:* SKILL.md push step 1.
+
+- **REQ-OP-007:** On partial push failure the step re-enumerates `External:` mappings and reports
+  pushed-vs-remaining; it never swallows the error. — *Rationale:* recoverable, auditable failure.
+  — *Verify:* SKILL.md push step 4; `upstream.py mappings`.
+
+- **REQ-OP-008:** Status/pull treats the upstream tracker as the authoritative worklist when enabled,
+  and falls back to local `bd ready` / `bd list` when disabled. — *Rationale:* the local bead set may
+  be stale relative to upstream. — *Verify:* SKILL.md "Status / pull" §.

--- a/skills/beads-upstream/spec/safety.md
+++ b/skills/beads-upstream/spec/safety.md
@@ -1,0 +1,34 @@
+# Spec: Safety invariants
+
+Non-negotiable constraints. A change that violates one of these is a defect, not a trade-off.
+
+## Requirements
+
+- **REQ-SAFE-001:** Never run a bare `bd <backend> sync`. Every push is `--push-only` (Jira:
+  `--push`) + scoped `--issues <ids>` or `--parent <id>`, with `--dry-run` first. — *Rationale:* a
+  bare sync re-imports all upstream issues as duplicate beads and pushes the entire local DB upstream.
+  — *Verify:* SKILL.md Safety invariants § + push step 3; protocols/UPSTREAM_TRACKING.md.
+
+- **REQ-SAFE-002:** Auth tokens are passed inline at call time (`TOKEN=$(...) bd <backend> …`) and
+  never written to config. — *Rationale:* tokens must not land in a version-controlled config store.
+  — *Verify:* SKILL.md init step 3 + push step 1; absence of any `bd config set *.token`.
+
+- **REQ-SAFE-003:** Re-pushing an already-mapped bead must not create a duplicate upstream issue;
+  the recovery story depends on the recorded `External:` mapping suppressing re-push. — *Rationale:*
+  partial-failure recovery re-runs the scoped push; it must be idempotent. — *Verify:* push step 5
+  (verified live, bd 1.0.5: re-push kept upstream issue count at 1).
+
+- **REQ-SAFE-004:** When tracking is disabled (`none`), the close-time rule trigger is a silent
+  no-op — no enumeration, prompt, or upstream call. — *Rationale:* opted-out projects are never
+  nagged. — *Verify:* protocols/UPSTREAM_TRACKING.md no-op clause; REQ-OP-004.
+
+- **REQ-SAFE-005:** `init` does not flip `dolt.local-only` to `true` without operator confirmation
+  when a dolt remote is already configured. — *Rationale:* the operator may run a dolt remote
+  intentionally. — *Verify:* SKILL.md init step 4 (`bd dolt remote list` guard).
+
+## Verification note
+
+`External:` mapping format and idempotency (REQ-SAFE-003) were verified live on bd 1.0.5 against a
+throwaway repo on 2026-06-01: `bd github push <id>` records `External: …/issues/N`; a second push
+of the same bead left the upstream count at 1. GitLab/Jira are unverified config-only stubs and
+must be live-tested before REQ-SAFE-003 is claimed for them.


### PR DESCRIPTION
Executes **plan-003-james-dixson-adacc7** (`docs/plans/plan-003-james-dixson-adacc7/`). All three epics closed; beads pushed to DoltHub.

## Epic 1 — Memory (M2)
- Delete `AGENTS/MEMORY.md`. The `CLAUDE.md` Memory section (M2 split: ephemeral `bd remember` vs. durable `AGENTS/` rules / upstreamed beads) already landed via the concurrent optimal-instructions refactor — this branch completes the deprecation. Grep sweep clean.

## Epic 2 — beads-upstream (new skill)
- GitHub-first **utility skill** (no formula/coordinator). `init` (backend `github|gitlab|jira|none`; `none` = first-class disabled, re-enableable), land-the-plane **push step** (disabled no-op → auth pre-flight → dry-run-first scoped `bd github push` → partial-push recovery), and **status/pull** worklist.
- `scripts/upstream.py` (`enumerate`/`mappings`, defensive `--json`). Always-loaded companion rule `protocols/UPSTREAM_TRACKING.md` + stamped `manifest.json`, auto-discovered by `install.sh` (install path smoke-tested). `spec/` drafted — **pending operator approval to activate**.
- **GitHub idempotency verified live** on bd 1.0.5 against a throwaway repo: re-push of a mapped bead kept the upstream count at 1; `External: …/issues/N` recorded.

## Epic 3 — plugin-bridge (beads-extra / beads-authoring)
- `beads-extra`: corrects-the-plugin callout (stale `bd gate approve/eval/close`, bare `bd pour/wisp`, `bd mol catalog`); accurate `bd create -t` list (probed live — `decision|gate|event|molecule` all accepted, so `molecule` retained **contra the plan's premise**, with operator sign-off); citations to the plugin's `DEPENDENCIES.md`/`WORKFLOWS.md`. Mirrored in `beads-authoring`.
- `CONSISTENCY.md` sub-agents on all three skills: no unresolved FAIL.

## Follow-ups filed (beads)
- `beads-skills-tvy` (P1, **operator action**): delete throwaway repo `dixson3/beads-upstream-idemtest` — the session token lacked `delete_repo` scope.
- `beads-skills-g3u` (P3): draft `spec/` for beads-extra/beads-authoring.
- `beads-skills-151` (P3): optimal-instructions K2 instruction-file restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)