### PR TITLE
yf-zlcq: remove transitional flat .yf/<short>.local.json config tier

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -64,6 +64,12 @@
 >   `GR-BINIT-002` that the embedded raw-`dolt` escape hatch is distinct from the forbidden
 >   `bd vc commit`. Engine: `yf/src/beads_init.rs` gains a `dolt-commit-embedded` native
 >   `apply_native` verb + mode-aware `Corrupted`-branch wiring.
+> - **plan-023 follow-up (2026-07-05, yf-zlcq):** removed the transitional flat
+>   `.yf/<short>.local.json` config tier now that the `.yf/<short>/config.local.json` migration is
+>   ubiquitous. `REQ-YF-PRE-004` drops read-precedence tier 2 (now subdir → legacy root dotfile);
+>   `REQ-YF-MIGRATE-001` drops the flat config migration source (config migrates only the legacy
+>   root dotfile `.<old>.local.json`). Engine: `read_config` (`preflight.rs`) and `migrate`
+>   (`migrate.rs`) drop the flat tier.
 
 ## 1. Purpose & scope
 
@@ -210,9 +216,7 @@ end-to-end by the `flow` module (as `marker` owns the SKILL.md marker).
   The **canonical** config location is `.yf/<short>/config.local.json` — co-located with the
   `.yf/<short>/` state dir. `read_config` shall resolve in precedence order, first match wins:
   1. the canonical subdir `.yf/<short>/config.local.json`;
-  2. the transitional flat `.yf/<short>.local.json` (back-compat read only — slated for removal
-     once migration is ubiquitous);
-  3. the legacy root dotfile named by the skill's `config_basename` descriptor field
+  2. the legacy root dotfile named by the skill's `config_basename` descriptor field
      (e.g. `.yf-plan.local.json`).
 
   The **short name** is resolved by a single centralized `resolve_skill` (skill-arg → `(dir,
@@ -391,16 +395,13 @@ end-to-end by the `flow` module (as `marker` owns the SKILL.md marker).
   state and config into the canonical `.yf/<short>/` namespace:
   - **state**: `.state/<old>/` → `.yf/<short>/` (short name, matching what preflight reads — not
     the full `.yf/<skill>/` the pre-#67 migrator wrote);
-  - **config**: both the legacy root dotfile `.<old>.local.json` **and** the transitional flat
-    `.yf/<short>.local.json` → `.yf/<short>/config.local.json`.
+  - **config**: the legacy root dotfile `.<old>.local.json` → `.yf/<short>/config.local.json`.
 
   Migration is idempotent and **never-clobber** (an existing dest is left untouched, source
   reported `skipped`), safe to re-run, and preserves values. `migrate` shall use the centralized
   `resolve_skill` (REQ-YF-PRE-004) for the short name so its dest matches preflight's read path.
   Migration shall also collapse legacy top-level per-skill gitignore anchors to the single `/.yf/`
-  anchor (REQ-YF-PRE-005). The flat `.yf/<short>.local.json` tier is **transitional** — a
-  back-compat read + migration source only, slated for removal once migration is ubiquitous (a
-  follow-up cleanup, filed at land-the-plane).
+  anchor (REQ-YF-PRE-005).
 
 ## 4. Skill catalog (per-skill specs)
 

--- a/yf/src/migrate.rs
+++ b/yf/src/migrate.rs
@@ -5,15 +5,14 @@
 //!
 //! - `.state/<oldname>/`         → `.yf/<short>/`
 //! - `.<oldname>.local.json`     → `.yf/<short>/config.local.json`
-//! - `.yf/<short>.local.json`    → `.yf/<short>/config.local.json` (transitional flat)
 //!
 //! where the `.yf/<short>/` namespace short name comes from the centralized
 //! [`crate::preflight::skill_short_name`] resolver — matching what preflight reads
 //! (e.g. `.state/bdplan/` → `.yf/plan/`, NOT the pre-#67 full-name `.yf/yf-plan/`).
-//! Config consolidates BOTH legacy sources (the root dotfile and the transitional
-//! flat `.yf/<short>.local.json`) into the canonical `.yf/<short>/config.local.json`
-//! subdir (#67), and the per-skill top-level gitignore anchors collapse to one
-//! `/.yf/` anchor.
+//! Config migrates the legacy root dotfile `.<old>.local.json` into the canonical
+//! `.yf/<short>/config.local.json` subdir (#67); the transitional flat
+//! `.yf/<short>.local.json` source was removed (yf-zlcq). The per-skill top-level
+//! gitignore anchors collapse to one `/.yf/` anchor.
 //!
 //! ## Idempotency guarantees (REQ-YF-MIGRATE-001)
 //!
@@ -106,16 +105,10 @@ pub fn migrate(repo: &Path, dry_run: bool) -> std::io::Result<MigrateResult> {
         )?);
 
         // Config → the canonical subdir `.yf/<short>/config.local.json` (REQ-YF-MIGRATE-001
-        // revised, #67). TWO legacy sources consolidate into the one dest, in
-        // READ-PRECEDENCE order so the value a reader currently sees is preserved:
-        //   (1) transitional flat `.yf/<short>.local.json` (read tier 2) — migrated first;
-        //   (2) legacy root `.<old>.local.json` (read tier 3) — DestExists if (1) moved.
-        // Both are idempotent + never-clobber (an existing dest is left untouched).
+        // revised, #67). The legacy root dotfile `.<old>.local.json` (read tier 2) is the
+        // sole migration source — the transitional flat `.yf/<short>.local.json` tier was
+        // removed (yf-zlcq). Idempotent + never-clobber (an existing dest is left untouched).
         let cfg_to = repo.join(".yf").join(&short).join("config.local.json");
-        let flat_from = repo.join(".yf").join(format!("{short}.local.json"));
-        entries.push(plan_and_apply(
-            "config", old, new, &flat_from, &cfg_to, dry_run,
-        )?);
         let legacy_from = repo.join(format!(".{old}.local.json"));
         entries.push(plan_and_apply(
             "config",
@@ -343,7 +336,7 @@ mod tests {
         std::fs::write(repo.join(".bdplan.local.json"), r#"{"k":1}"#).unwrap();
 
         let res = migrate(repo, false).unwrap();
-        // state + legacy-root config → 2 (flat config source absent here).
+        // state + legacy-root config → 2.
         assert_eq!(res.migrated, 2);
 
         // New paths exist with content (state dir + config subdir use the SHORT name).
@@ -437,10 +430,11 @@ mod tests {
         assert!(res.entries.iter().all(|e| e.action == Action::SourceAbsent));
     }
 
-    // REQ-YF-MIGRATE-001 (#67): the transitional flat `.yf/<short>.local.json`
-    // migrates into the canonical `.yf/<short>/config.local.json` subdir.
+    // REQ-YF-MIGRATE-001 (yf-zlcq): the transitional flat `.yf/<short>.local.json`
+    // migration source was REMOVED — a flat-only repo migrates no config and the flat
+    // file is left untouched (it is no longer read or migrated anywhere).
     #[test]
-    fn flat_config_migrates_to_subdir() {
+    fn flat_config_is_ignored() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         std::fs::create_dir_all(repo.join(".yf")).unwrap();
@@ -451,20 +445,21 @@ mod tests {
         .unwrap();
 
         let res = migrate(repo, false).unwrap();
-        assert_eq!(res.migrated, 1);
-        assert_eq!(
-            std::fs::read_to_string(repo.join(".yf").join("plan").join("config.local.json"))
-                .unwrap(),
-            r#"{"src":"flat"}"#
-        );
-        assert!(!repo.join(".yf").join("plan.local.json").exists());
+        // No config source is present (the flat tier is gone) → nothing migrates.
+        assert_eq!(res.migrated, 0);
+        assert!(!repo
+            .join(".yf")
+            .join("plan")
+            .join("config.local.json")
+            .exists());
+        // The flat file is left where it is — never read, never moved.
+        assert!(repo.join(".yf").join("plan.local.json").is_file());
     }
 
-    // REQ-YF-MIGRATE-001 (#67): when BOTH a flat and a legacy-root config exist, the
-    // flat (higher read-precedence, tier 2) wins the subdir; the legacy source is
-    // left untouched (never-clobber), preserving the value a reader currently sees.
+    // REQ-YF-MIGRATE-001 (yf-zlcq): the legacy-root dotfile is the sole config source;
+    // it migrates to the canonical subdir even when a (now-ignored) flat file coexists.
     #[test]
-    fn flat_wins_over_legacy_on_consolidation() {
+    fn legacy_root_migrates_flat_ignored() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         std::fs::create_dir_all(repo.join(".yf")).unwrap();
@@ -476,16 +471,15 @@ mod tests {
         std::fs::write(repo.join(".bdplan.local.json"), r#"{"src":"legacy"}"#).unwrap();
 
         migrate(repo, false).unwrap();
-        // The subdir carries the flat value; the legacy file is left in place.
+        // The subdir carries the legacy-root value (the flat file is ignored).
         assert_eq!(
             std::fs::read_to_string(repo.join(".yf").join("plan").join("config.local.json"))
                 .unwrap(),
-            r#"{"src":"flat"}"#
+            r#"{"src":"legacy"}"#
         );
-        assert!(
-            repo.join(".bdplan.local.json").is_file(),
-            "legacy source left untouched (never-clobber)"
-        );
+        // Legacy source consumed by the migration; flat file untouched.
+        assert!(!repo.join(".bdplan.local.json").exists());
+        assert!(repo.join(".yf").join("plan.local.json").is_file());
     }
 
     // REQ-YF-PRE-005 revised (#67): legacy per-skill top-level gitignore anchors

--- a/yf/src/preflight.rs
+++ b/yf/src/preflight.rs
@@ -439,8 +439,8 @@ fn skill_tools(skill_dir: &str) -> Vec<String> {
 // Config + state (REQ-YF-PRE-004)
 // ---------------------------------------------------------------------------
 
-/// Read per-skill operator config. Precedence: the new `.yf/<skill>.local.json`,
-/// then the legacy `.<config-basename>` at repo root (contract §7).
+/// Read per-skill operator config. Precedence: the canonical
+/// `.yf/<short>/config.local.json`, then the legacy `.<config-basename>` at repo root.
 fn read_config(
     env: &Env,
     short: &str,
@@ -448,15 +448,10 @@ fn read_config(
 ) -> serde_json::Map<String, serde_json::Value> {
     // REQ-YF-PRE-004 resolution precedence, first match wins:
     // 1. canonical subdir `.yf/<short>/config.local.json` (co-located with state);
-    // 2. transitional flat `.yf/<short>.local.json` (back-compat read only);
-    // 3. legacy root dotfile named by the skill's `config_basename` descriptor.
+    // 2. legacy root dotfile named by the skill's `config_basename` descriptor.
     let yf = env.repo_root.join(".yf");
     let subdir_path = yf.join(short).join("config.local.json");
     if let Some(m) = read_json_obj(&subdir_path) {
-        return m;
-    }
-    let flat_path = yf.join(format!("{short}.local.json"));
-    if let Some(m) = read_json_obj(&flat_path) {
         return m;
     }
     if let Some(base) = config_basename {
@@ -1108,14 +1103,14 @@ mod tests {
         base
     }
 
-    // REQ-YF-PRE-004: ignore-skill in config short-circuits to `ignored`.
+    // REQ-YF-PRE-004: ignore-skill in the canonical subdir config short-circuits to `ignored`.
     #[test]
     fn ignore_skill_short_circuits() {
         let tmp = unique_tmp("ignore");
         let repo = tmp.join("repo");
-        std::fs::create_dir_all(repo.join(".yf")).unwrap();
+        std::fs::create_dir_all(repo.join(".yf").join("plan")).unwrap();
         std::fs::write(
-            repo.join(".yf").join("plan.local.json"),
+            repo.join(".yf").join("plan").join("config.local.json"),
             r#"{"ignore-skill": true}"#,
         )
         .unwrap();
@@ -2065,11 +2060,11 @@ mod tests {
         std::fs::remove_dir_all(&repo).ok();
     }
 
-    // REQ-YF-PRE-004 (#67): read_config resolution precedence — canonical subdir
-    // `.yf/<short>/config.local.json` > transitional flat `.yf/<short>.local.json` >
-    // legacy root dotfile. Also proves (pass-1 concern 4) that config resolution is
-    // DECOUPLED from the state short-name: config still resolves for `plan` (short)
-    // after the SKILL_MAP state-dir change.
+    // REQ-YF-PRE-004 (yf-zlcq): read_config resolution precedence — canonical subdir
+    // `.yf/<short>/config.local.json` > legacy root dotfile. The transitional flat
+    // `.yf/<short>.local.json` tier was removed and is now IGNORED. Also proves (pass-1
+    // concern 4) that config resolution is DECOUPLED from the state short-name: config
+    // still resolves for `plan` (short) after the SKILL_MAP state-dir change.
     #[test]
     fn read_config_resolution_precedence() {
         let repo = unique_tmp("cfg-precedence");
@@ -2079,7 +2074,7 @@ mod tests {
         std::fs::create_dir_all(yf.join("plan")).unwrap();
         let basename = ".yf-plan.local.json";
 
-        // Tier 3 only: legacy root dotfile.
+        // Tier 2 only: legacy root dotfile.
         std::fs::write(repo.join(basename), r#"{"src":"legacy"}"#).unwrap();
         assert_eq!(
             read_config(&env, "plan", Some(basename))
@@ -2088,13 +2083,14 @@ mod tests {
             "legacy"
         );
 
-        // Tier 2 wins over tier 3: flat `.yf/<short>.local.json`.
+        // The removed flat `.yf/<short>.local.json` tier is IGNORED — the legacy root
+        // dotfile still wins over it (no back-compat read of the flat file).
         std::fs::write(yf.join("plan.local.json"), r#"{"src":"flat"}"#).unwrap();
         assert_eq!(
             read_config(&env, "plan", Some(basename))
                 .get("src")
                 .unwrap(),
-            "flat"
+            "legacy"
         );
 
         // Tier 1 wins over all: canonical subdir `.yf/<short>/config.local.json`.


### PR DESCRIPTION
Post-#67 cleanup (bead `yf-zlcq`, follow-up from plan-023 Issue 2.3): removes the transitional flat `.yf/<short>.local.json` config tier now that the `.yf/<short>/config.local.json` migration is ubiquitous.

## Changes (SPEC-first)

- **SPEC.md** — `REQ-YF-PRE-004` drops read-precedence tier 2 (subdir → legacy root dotfile); `REQ-YF-MIGRATE-001` migrates config only from the legacy root dotfile `.<old>.local.json`; amendment-log entry added.
- **yf/src/preflight.rs** — `read_config` drops the flat lookup; precedence test asserts the flat file is now ignored; `ignore_skill_short_circuits` seeds the canonical subdir.
- **yf/src/migrate.rs** — removes the flat config migration source; the two flat tests are replaced with `flat_config_is_ignored` and `legacy_root_migrates_flat_ignored`.

## Validation

- `cargo fmt --check` / `cargo clippy -D warnings` clean.
- change-validation **FULL tier PASS** — 229 rust tests + all skill suites.
- drift-check edges (SPEC↔GUARDRAILS, SPEC↔README) verified in agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)