### PR TITLE
yf-plan commit-plan local-only fix + change-validation FAST fmt row (#71, #45)

### DIFF
--- a/CHANGE-VALIDATION.md
+++ b/CHANGE-VALIDATION.md
@@ -16,6 +16,7 @@ approved: yes
 
 | id | cmd | cwd | timeout |
 |:--|:--|:--|--:|
+| `cargo-fmt` | `cargo fmt --all -- --check` |  |  |
 | `cargo` | `cargo test --workspace` |  |  |
 | `uv` | `uv run --with pytest python3 -m pytest _shared/test_sync.py -q` |  |  |
 | `uv-run` | `uv run --with pytest python3 -m pytest skills/yf-beads-hygiene/scripts/test_beads_hygiene.py -q` |  |  |
@@ -56,10 +57,10 @@ approved: yes
 
 | changed-path glob | scopes to (FAST ids) |
 |:--|:--|
-| `*.rs` | `cargo` |
-| `**/*.rs` | `cargo` |
-| `Cargo.toml` | `cargo` |
-| `**/Cargo.toml` | `cargo` |
+| `*.rs` | `cargo-fmt`, `cargo` |
+| `**/*.rs` | `cargo-fmt`, `cargo` |
+| `Cargo.toml` | `cargo-fmt`, `cargo` |
+| `**/Cargo.toml` | `cargo-fmt`, `cargo` |
 | `_shared/**` | `uv`, `uv-_shared` |
 | `_shared/test_sync.py` | `uv` |
 | `skills/yf-beads-hygiene/scripts/**` | `uv-run` |

--- a/skills/yf-plan/SKILL.md
+++ b/skills/yf-plan/SKILL.md
@@ -487,9 +487,11 @@ token.
 ### 4.3 — Auto-commit the plan locally
 
 Commit the approved plan **locally** so a fresh execute session (or a fresh clone after a
-crash) inherits a committed base (REQ-PLAN-064). `commit-plan` does a scoped
-`git add -- "${plan_dir}" .beads/` (explicit pathspec, never `git add -A`), a local commit
-(message `plan-NNN: <phase> — <objective>`), and **never a push**:
+crash) inherits a committed base (REQ-PLAN-064). `commit-plan` does a scoped `git add` over an
+explicit pathspec (never `git add -A`) — always `${plan_dir}`, plus `.beads/` **only when it is
+tracked / not gitignored** (a local-only beads repo gitignores `.beads/`, so it is skipped with a
+`beads_note` rather than failing, #71) — a local commit (message `plan-NNN: <phase> —
+<objective>`), and **never a push**:
 
 ```bash
 uv run ${SKILL_DIR}/scripts/plan_manager.py commit-plan "${plan_dir}" --json

--- a/skills/yf-plan/SPEC.md
+++ b/skills/yf-plan/SPEC.md
@@ -117,10 +117,13 @@ execution with merge-back, crash-resume, and upstream triage/reconciliation.
   reconciler agent), then close the reconcile step + epic and set status `complete`.
 - **REQ-PLAN-064** *(testable)* at the PLAN→EXECUTE landing boundary (after the portability audit and
   the fingerprint write, REQ-PLAN-034), the plan shall be auto-committed **locally** via
-  `plan_manager.py commit-plan`: a scoped `git add -- "${plan_dir}" .beads/` (explicit pathspec,
-  never `git add -A`), a local commit (message `plan-NNN: <phase> — <objective>`), and **never a
-  push**. This is the #63 clean-handoff boundary — a fresh execute session inherits a committed base,
-  and intake artifacts survive a crash or fresh clone.
+  `plan_manager.py commit-plan`: a scoped `git add` over an explicit pathspec (never `git add -A`) —
+  always `${plan_dir}`, and `.beads/` **only when it is tracked / not gitignored**. On a local-only
+  beads repo `.beads/` is intentionally gitignored (gh-only interchange), where co-adding it would
+  fail; commit-plan shall skip the `.beads/` pathspec (surfacing a `beads_note`) rather than erroring
+  (#71). Then a local commit (message `plan-NNN: <phase> — <objective>`), and **never a push**. This
+  is the #63 clean-handoff boundary — a fresh execute session inherits a committed base, and intake
+  artifacts survive a crash or fresh clone.
 - **REQ-PLAN-065** *(testable)* `commit-plan` shall refuse to commit on the repository's default
   branch. Default-branch resolution is `git symbolic-ref --short refs/remotes/origin/HEAD` →
   `git config init.defaultBranch` → `main`/`master`. A **detached HEAD or an empty current-branch

--- a/skills/yf-plan/scripts/plan_manager.py
+++ b/skills/yf-plan/scripts/plan_manager.py
@@ -1114,14 +1114,29 @@ def _commit_plan(plan_dir: Path) -> dict:
     objective = _read_plan_objective(text) or plan_id
 
     # Scoped staging — explicit pathspec, NEVER `git add -A` (REQ-PLAN-064).
-    add = _run_git(["add", "--", str(plan_dir), ".beads"], cwd=repo_root)
+    # The plan dir is always addable; `.beads/` is co-committed ONLY when it is
+    # tracked/not-ignored. On a local-only beads repo `.beads/` is intentionally
+    # gitignored (gh-only interchange), where `git add -- .beads` fails outright —
+    # so skip that pathspec instead of erroring (issue #71).
+    addpaths = [str(plan_dir)]
+    beads_note = None
+    if (repo_root / ".beads").exists():
+        ignored = _run_git(["check-ignore", "-q", ".beads"], cwd=repo_root).returncode == 0
+        if ignored:
+            beads_note = ".beads/ is gitignored (local-only beads) — not co-committed."
+        else:
+            addpaths.append(".beads")
+    add = _run_git(["add", "--", *addpaths], cwd=repo_root)
     if add.returncode != 0:
         return {"status": "error", "branch": cur,
                 "detail": f"git add failed: {add.stderr.strip()}"}
     # Nothing staged → no-op (idempotent re-runs don't create empty commits).
     if _run_git(["diff", "--cached", "--quiet"], cwd=repo_root).returncode == 0:
-        return {"status": "noop", "branch": cur,
-                "detail": "no staged changes under the plan folder / .beads."}
+        result = {"status": "noop", "branch": cur,
+                  "detail": "no staged changes under the plan folder / .beads."}
+        if beads_note:
+            result["beads_note"] = beads_note
+        return result
 
     message = f"{plan_id}: {phase} — {objective}"
     commit = _run_git(["commit", "-m", message], cwd=repo_root)
@@ -1129,7 +1144,10 @@ def _commit_plan(plan_dir: Path) -> dict:
         return {"status": "error", "branch": cur,
                 "detail": f"git commit failed: {commit.stderr.strip()}"}
     sha = _run_git(["rev-parse", "--short", "HEAD"], cwd=repo_root).stdout.strip()
-    return {"status": "committed", "branch": cur, "commit": sha, "message": message}
+    result = {"status": "committed", "branch": cur, "commit": sha, "message": message}
+    if beads_note:
+        result["beads_note"] = beads_note
+    return result
 
 
 @cli.command("commit-plan")

--- a/skills/yf-plan/scripts/test_worktree.py
+++ b/skills/yf-plan/scripts/test_worktree.py
@@ -712,5 +712,35 @@ def test_commit_plan_commits_on_plan_branch_then_noop(git_repo):
     assert pm._commit_plan(pd)["status"] == "noop"
 
 
+def test_commit_plan_skips_gitignored_beads_local_only(git_repo):
+    # Local-only beads: `.beads/` is gitignored (gh-only interchange). commit-plan
+    # must commit the plan dir cleanly and SKIP `.beads/` instead of erroring on the
+    # ignored pathspec (#71). Without the fix `git add -- ... .beads` fails.
+    (git_repo / ".beads" / "local.db").write_text("x")  # an ignored path under .beads
+    (git_repo / ".gitignore").write_text(".beads/\n")
+    pm._run_git(["add", ".gitignore"], cwd=git_repo)
+    pm._run_git(["commit", "-m", "ignore beads"], cwd=git_repo)
+    pd = _seed_plan(git_repo, branch="plan-777")
+    r = pm._commit_plan(pd)
+    assert r["status"] == "committed"
+    assert "beads_note" in r  # operator told beads state was not co-committed
+    # `.beads/` must NOT be in the commit (it is ignored).
+    files = pm._run_git(
+        ["show", "--name-only", "--pretty=format:", "HEAD"], cwd=git_repo).stdout
+    assert ".beads" not in files
+
+
+def test_commit_plan_co_commits_tracked_beads(git_repo):
+    # The standard (non-local-only) model: `.beads/` is tracked, so it is co-committed.
+    (git_repo / ".beads" / "issues.jsonl").write_text('{"id":"x"}\n')
+    pd = _seed_plan(git_repo, branch="plan-778")
+    r = pm._commit_plan(pd)
+    assert r["status"] == "committed"
+    assert "beads_note" not in r
+    files = pm._run_git(
+        ["show", "--name-only", "--pretty=format:", "HEAD"], cwd=git_repo).stdout
+    assert ".beads/issues.jsonl" in files
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## #71 — commit-plan fails on local-only repos where `.beads/` is gitignored

`_commit_plan` did an unconditional `git add -- "${plan_dir}" .beads`. On a local-only beads repo (`.beads/` gitignored, `gh`-only interchange) the ignored pathspec makes `git add` fail → `status: error`, blocking intake.

- Pathspec is now conditional: `${plan_dir}` always; `.beads/` only when it exists **and** is not gitignored (`git check-ignore`). When skipped, a `beads_note` tells the operator beads state was not co-committed.
- **SPEC-first:** REQ-PLAN-064 amended for the local-only carve-out; SKILL.md §4.3 echoes it so spec/skill/impl agree (yf-drift-check edges).
- Tests: gitignored `.beads` → committed + `beads_note`, `.beads` absent from commit; tracked `.beads` → co-committed, no note.

## #45 — change-validation FAST tier omits `cargo fmt --check` for `.rs` edits

FAST scoped `.rs` edits to `cargo test` only, so fmt drift slipped past local validation and only failed in CI (bit v0.3.2). Added a dedicated `cargo-fmt` FAST id (`cargo fmt --all -- --check`) and scoped the `*.rs` / `**/*.rs` / `Cargo.toml` globs to `cargo-fmt`, `cargo`. clippy stays FULL-only (multi-minute compile). A `.rs` edit now yields a fmt FAIL before push.

## Validation

FULL tier: all pass — fmt / clippy / `cargo test --workspace` + every pytest suite (45 yf-plan tests). markdown-lint clean on all edited docs.

Closes #71
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)